### PR TITLE
ci: fix tidy-check job

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -23,7 +23,7 @@ jobs:
 
   code-quality-check:
     name: Code Quality Check
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@v1.4.4
+    uses: noorts/extension-ci-tools/.github/workflows/_extension_code_quality.yml@fix-tidy-check-vcpkg
     with:
       duckdb_version: v1.4.4
       ci_tools_version: fix-tidy-check-vcpkg

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -26,6 +26,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@v1.4.4
     with:
       duckdb_version: v1.4.4
-      ci_tools_version: v1.4.4
+      ci_tools_version: fix-tidy-check-vcpkg
+      override_ci_tools_repository: noorts/extension-ci-tools
       extension_name: pdxearch
       format_checks: 'format;tidy'


### PR DESCRIPTION
Temporary use of a forked `extension-ci-tools` repo while waiting until a tidy-check fix is merged upstream.