### PR TITLE
[PDX Core]: Removing static variables, redundant methods and guards

### DIFF
--- a/src/include/index/pdxearch_index_utils.hpp
+++ b/src/include/index/pdxearch_index_utils.hpp
@@ -109,8 +109,7 @@ private:
 public:
 	explicit EmbeddingPreprocessor(const size_t num_dimensions, const float *const rotation_matrix,
 	                               const float epsilon0)
-	    : pruner(num_dimensions, epsilon0, rotation_matrix), quantizer(), num_dimensions(num_dimensions) {
-		quantizer.SetD(num_dimensions);
+	    : pruner(num_dimensions, epsilon0, rotation_matrix), quantizer(num_dimensions), num_dimensions(num_dimensions) {
 	}
 
 	// Warning: modifies the input_embedding.

--- a/src/include/index/pdxearch_wrapper.hpp
+++ b/src/include/index/pdxearch_wrapper.hpp
@@ -189,8 +189,7 @@ public:
 		}
 
 		// Note: the searcher depends on a fully initialized index in its constructor.
-		row_group.searcher = make_uniq<PDX::PDXearch<PDX::F32>>(*row_group.index, *row_group.pruner, 1,
-		                                                        PDX::DimensionsOrder::SEQUENTIAL);
+		row_group.searcher = make_uniq<PDX::PDXearch<PDX::F32>>(*row_group.index, *row_group.pruner);
 	}
 
 	void InitializeSearchForRowGroup(float *const preprocessed_query_embedding, const idx_t limit,
@@ -311,7 +310,7 @@ public:
 		}
 
 		// Note: the searcher depends on a fully initialized index in its constructor.
-		searcher = make_uniq<PDX::PDXearch<PDX::F32>>(*index, *pruner, 1, PDX::DimensionsOrder::SEQUENTIAL);
+		searcher = make_uniq<PDX::PDXearch<PDX::F32>>(*index, *pruner);
 	}
 
 	std::unique_ptr<std::vector<row_t>> Search(const float *const query_embedding, const idx_t limit,

--- a/src/include/pdxearch/common.hpp
+++ b/src/include/pdxearch/common.hpp
@@ -1,5 +1,4 @@
-#ifndef PDX_COMMON_HPP
-#define PDX_COMMON_HPP
+#pragma once
 
 #include <cstdint>
 #include <cstdio>
@@ -15,41 +14,22 @@ static constexpr size_t PDX_MAX_DIMS = 4096;
 static constexpr size_t PDX_MIN_DIMS = 128;
 static constexpr size_t MAX_EMBEDDINGS_PER_CLUSTER = 10240;
 
+static constexpr size_t H_DIM_SIZE = 64;
+static constexpr uint32_t DIMENSIONS_FETCHING_SIZES[24] = {
+	4, 4, 8, 8, 8, 16, 16, 32, 32, 32, 32, 64, 64, 64, 64, 128, 128, 128, 128, 256, 256, 512, 1024, 2048};
+
 template <class T, T val = 8>
 static constexpr uint32_t AlignValue(T n) {
 	return ((n + (val - 1)) / val) * val;
 }
 
-enum DimensionsOrder {
-	SEQUENTIAL,
-	DISTANCE_TO_MEANS,
-	DECREASING,
-	DISTANCE_TO_MEANS_IMPROVED,
-	DECREASING_IMPROVED,
-	DIMENSION_ZONES
-};
-
-// Distance metric functionality that is exposed externally.
 enum class DistanceMetric { L2SQ, COSINE, IP };
-
-// Used internally.
-enum DistanceFunction {
-	L2,
-	IP,
-	L1,
-	NEGATIVE_L2 // Only the negative term of L2 (-2*q[i]*d[i])
-};
 
 enum Quantization {
 	F32,
 	U8,
-	// TODO:
 	F16,
-	BF,
-	U6,
-	U4,
-	ASYMMETRIC_U8,
-	ASYMMETRIC_LEP_U8
+	BF
 };
 
 // TODO: Do the same for indexes?
@@ -174,4 +154,3 @@ static_assert(GetPDXDimensionSplit(1028).vertical_dimensions == 260);
 
 }; // namespace PDX
 
-#endif // PDX_COMMON_HPP

--- a/src/include/pdxearch/common.hpp
+++ b/src/include/pdxearch/common.hpp
@@ -15,8 +15,8 @@ static constexpr size_t PDX_MIN_DIMS = 128;
 static constexpr size_t MAX_EMBEDDINGS_PER_CLUSTER = 10240;
 
 static constexpr size_t H_DIM_SIZE = 64;
-static constexpr uint32_t DIMENSIONS_FETCHING_SIZES[24] = {
-	4, 4, 8, 8, 8, 16, 16, 32, 32, 32, 32, 64, 64, 64, 64, 128, 128, 128, 128, 256, 256, 512, 1024, 2048};
+static constexpr uint32_t DIMENSIONS_FETCHING_SIZES[24] = {4,  4,  8,  8,   8,   16,  16,  32,  32,  32,  32,   64,
+                                                           64, 64, 64, 128, 128, 128, 128, 256, 256, 512, 1024, 2048};
 
 template <class T, T val = 8>
 static constexpr uint32_t AlignValue(T n) {
@@ -25,12 +25,7 @@ static constexpr uint32_t AlignValue(T n) {
 
 enum class DistanceMetric { L2SQ, COSINE, IP };
 
-enum Quantization {
-	F32,
-	U8,
-	F16,
-	BF
-};
+enum Quantization { F32, U8, F16, BF };
 
 // TODO: Do the same for indexes?
 template <Quantization q>
@@ -153,4 +148,3 @@ static_assert(GetPDXDimensionSplit(1028).horizontal_dimensions == 768);
 static_assert(GetPDXDimensionSplit(1028).vertical_dimensions == 260);
 
 }; // namespace PDX
-

--- a/src/include/pdxearch/db_mock/predicate_evaluator.hpp
+++ b/src/include/pdxearch/db_mock/predicate_evaluator.hpp
@@ -27,5 +27,3 @@ public:
 };
 
 }; // namespace PDX
-
-

--- a/src/include/pdxearch/db_mock/predicate_evaluator.hpp
+++ b/src/include/pdxearch/db_mock/predicate_evaluator.hpp
@@ -1,5 +1,4 @@
-#ifndef PDX_PREDICATE_EVALUATOR_H
-#define PDX_PREDICATE_EVALUATOR_H
+#pragma once
 
 #include <memory>
 #include <cstdint>
@@ -29,4 +28,4 @@ public:
 
 }; // namespace PDX
 
-#endif // PDX_PREDICATE_EVALUATOR_H
+

--- a/src/include/pdxearch/distance_computers/avx2_computers.hpp
+++ b/src/include/pdxearch/distance_computers/avx2_computers.hpp
@@ -8,16 +8,16 @@
 
 namespace PDX {
 
-template <DistanceFunction alpha, Quantization q>
+template <DistanceMetric alpha, Quantization q>
 class SIMDComputer {};
 
 template <>
-class SIMDComputer<L2, Quantization::F32> {
+class SIMDComputer<DistanceMetric::L2SQ, Quantization::F32> {
 public:
 	using DISTANCE_TYPE = DistanceType_t<F32>;
 	using QUERY_TYPE = QuantizedVectorType_t<F32>;
 	using DATA_TYPE = DataType_t<F32>;
-	using scalar_computer = ScalarComputer<L2, Quantization::F32>;
+	using scalar_computer = ScalarComputer<DistanceMetric::L2SQ, Quantization::F32>;
 
 	alignas(64) static DISTANCE_TYPE pruning_distances_tmp[4096];
 

--- a/src/include/pdxearch/distance_computers/avx2_computers.hpp
+++ b/src/include/pdxearch/distance_computers/avx2_computers.hpp
@@ -1,5 +1,4 @@
-#ifndef PDX_AVX2_COMPUTERS_HPP
-#define PDX_AVX2_COMPUTERS_HPP
+#pragma once
 
 #include <cstdint>
 #include <cstdio>
@@ -105,4 +104,3 @@ public:
 
 } // namespace PDX
 
-#endif // PDX_AVX2_COMPUTERS_HPP

--- a/src/include/pdxearch/distance_computers/avx2_computers.hpp
+++ b/src/include/pdxearch/distance_computers/avx2_computers.hpp
@@ -103,4 +103,3 @@ public:
 };
 
 } // namespace PDX
-

--- a/src/include/pdxearch/distance_computers/avx512_computers.hpp
+++ b/src/include/pdxearch/distance_computers/avx512_computers.hpp
@@ -9,16 +9,16 @@
 
 namespace PDX {
 
-template <DistanceFunction alpha, Quantization q>
+template <DistanceMetric alpha, Quantization q>
 class SIMDComputer {};
 
 template <>
-class SIMDComputer<L2, Quantization::F32> {
+class SIMDComputer<DistanceMetric::L2SQ, Quantization::F32> {
 public:
 	using DISTANCE_TYPE = DistanceType_t<F32>;
 	using QUERY_TYPE = QuantizedVectorType_t<F32>;
 	using DATA_TYPE = DataType_t<F32>;
-	using scalar_computer = ScalarComputer<L2, Quantization::F32>;
+	using scalar_computer = ScalarComputer<DistanceMetric::L2SQ, Quantization::F32>;
 
 	alignas(64) static DISTANCE_TYPE pruning_distances_tmp[4096];
 

--- a/src/include/pdxearch/distance_computers/avx512_computers.hpp
+++ b/src/include/pdxearch/distance_computers/avx512_computers.hpp
@@ -1,5 +1,4 @@
-#ifndef PDX_AVX512_COMPUTERS_HPP
-#define PDX_AVX512_COMPUTERS_HPP
+#pragma once
 
 #include <cstdint>
 #include <cstdio>
@@ -172,5 +171,3 @@ public:
 };
 
 } // namespace PDX
-
-#endif // PDX_AVX512_COMPUTERS_HPP

--- a/src/include/pdxearch/distance_computers/base_computers.hpp
+++ b/src/include/pdxearch/distance_computers/base_computers.hpp
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef PDX_BASE_COMPUTERS_HPP
-#define PDX_BASE_COMPUTERS_HPP
 
 #include "pdxearch/common.hpp"
 
@@ -48,4 +46,3 @@ public:
 
 }; // namespace PDX
 
-#endif // PDX_BASE_COMPUTERS_HPP

--- a/src/include/pdxearch/distance_computers/base_computers.hpp
+++ b/src/include/pdxearch/distance_computers/base_computers.hpp
@@ -23,15 +23,15 @@
 
 namespace PDX {
 
-template <DistanceFunction alpha, Quantization q>
+template <DistanceMetric alpha, Quantization q>
 class DistanceComputer {};
 
 template <>
-class DistanceComputer<L2, Quantization::F32> {
+class DistanceComputer<DistanceMetric::L2SQ, Quantization::F32> {
 #if !defined(__ARM_NEON) && !defined(__AVX2__) && !defined(__AVX512F__)
-	using computer = ScalarComputer<L2, F32>;
+	using computer = ScalarComputer<DistanceMetric::L2SQ, F32>;
 #else
-	using computer = SIMDComputer<L2, F32>;
+	using computer = SIMDComputer<DistanceMetric::L2SQ, F32>;
 #endif
 
 public:

--- a/src/include/pdxearch/distance_computers/base_computers.hpp
+++ b/src/include/pdxearch/distance_computers/base_computers.hpp
@@ -45,4 +45,3 @@ public:
 };
 
 }; // namespace PDX
-

--- a/src/include/pdxearch/distance_computers/neon_computers.hpp
+++ b/src/include/pdxearch/distance_computers/neon_computers.hpp
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef PDX_NEON_COMPUTERS_HPP
-#define PDX_NEON_COMPUTERS_HPP
 
 #include <cstdint>
 #include <cstdio>
@@ -87,5 +85,3 @@ public:
 };
 
 } // namespace PDX
-
-#endif // PDX_NEON_COMPUTERS_HPP

--- a/src/include/pdxearch/distance_computers/neon_computers.hpp
+++ b/src/include/pdxearch/distance_computers/neon_computers.hpp
@@ -7,11 +7,11 @@
 
 namespace PDX {
 
-template <DistanceFunction alpha, Quantization q>
+template <DistanceMetric alpha, Quantization q>
 class SIMDComputer {};
 
 template <>
-class SIMDComputer<L2, Quantization::F32> {
+class SIMDComputer<DistanceMetric::L2SQ, Quantization::F32> {
 public:
 	using DISTANCE_TYPE = DistanceType_t<F32>;
 	using QUERY_TYPE = QuantizedVectorType_t<F32>;

--- a/src/include/pdxearch/distance_computers/scalar_computers.hpp
+++ b/src/include/pdxearch/distance_computers/scalar_computers.hpp
@@ -6,11 +6,11 @@
 
 namespace PDX {
 
-template <DistanceFunction alpha, Quantization q>
+template <DistanceMetric alpha, Quantization q>
 class ScalarComputer {};
 
 template <>
-class ScalarComputer<L2, Quantization::F32> {
+class ScalarComputer<DistanceMetric::L2SQ, Quantization::F32> {
 public:
 	using DISTANCE_TYPE = DistanceType_t<F32>;
 	using QUERY_TYPE = QuantizedVectorType_t<F32>;

--- a/src/include/pdxearch/distance_computers/scalar_computers.hpp
+++ b/src/include/pdxearch/distance_computers/scalar_computers.hpp
@@ -1,5 +1,4 @@
-#ifndef PDX_SCALAR_COMPUTERS_HPP
-#define PDX_SCALAR_COMPUTERS_HPP
+#pragma once
 
 #include <cstdint>
 #include <cstdio>
@@ -72,5 +71,3 @@ public:
 };
 
 } // namespace PDX
-
-#endif // PDX_SCALAR_COMPUTERS_HPP

--- a/src/include/pdxearch/index_base/pdx_ivf.hpp
+++ b/src/include/pdxearch/index_base/pdx_ivf.hpp
@@ -1,5 +1,4 @@
-#ifndef PDX_IVF_HPP
-#define PDX_IVF_HPP
+#pragma once
 
 #include <cstdint>
 #include <cassert>
@@ -37,5 +36,3 @@ public:
 };
 
 } // namespace PDX
-
-#endif // PDX_IVF_HPP

--- a/src/include/pdxearch/pdxearch.hpp
+++ b/src/include/pdxearch/pdxearch.hpp
@@ -29,7 +29,8 @@ public:
 	Pruner &pruner;
 	INDEX_TYPE &pdx_data;
 
-	PDXearch(INDEX_TYPE &data_index, Pruner &pruner) : pruner(pruner), pdx_data(data_index) {
+	PDXearch(INDEX_TYPE &data_index, Pruner &pruner)
+	    : quantizer(data_index.num_dimensions), pruner(pruner), pdx_data(data_index) {
 		indices_dimensions.resize(pdx_data.num_dimensions);
 		cluster_indices_in_access_order.resize(pdx_data.num_clusters);
 		cluster_offsets.resize(pdx_data.num_clusters);
@@ -37,7 +38,6 @@ public:
 			cluster_offsets[i] = total_embeddings;
 			total_embeddings += pdx_data.clusters[i].num_embeddings;
 		}
-		quantizer.SetD(pdx_data.num_dimensions);
 	}
 
 	void SetNProbe(size_t nprobe) {
@@ -523,7 +523,6 @@ public:
 		// TODO: Incorporate this to U8 PDX (no IVF2)
 		// GetClustersAccessOrderIVFPDX(query);
 		std::vector<uint32_t> local_cluster_order;
-		local_cluster_order.resize(pdx_data.num_clusters);
 		GetClustersAccessOrderIVF(query, pdx_data, clusters_to_visit, local_cluster_order);
 		// PDXearch core
 		alignas(64) int32_t local_dim_clip_value[PDX_MAX_DIMS] = {};
@@ -584,7 +583,6 @@ public:
 		    (ivf_nprobe == 0 || ivf_nprobe > pdx_data.num_clusters) ? pdx_data.num_clusters : ivf_nprobe;
 
 		std::vector<uint32_t> local_cluster_order;
-		local_cluster_order.resize(pdx_data.num_clusters);
 		GetClustersAccessOrderIVF(query, pdx_data, clusters_to_visit, local_cluster_order);
 		// PDXearch core
 		alignas(64) int32_t local_dim_clip_value[PDX_MAX_DIMS] = {};

--- a/src/include/pdxearch/pdxearch.hpp
+++ b/src/include/pdxearch/pdxearch.hpp
@@ -15,7 +15,7 @@
 namespace PDX {
 
 template <Quantization q = F32, class Index = IndexPDXIVF<q>, class Quantizer = Global8Quantizer<q>,
-          DistanceFunction alpha = L2, class Pruner = ADSamplingPruner<q>>
+          DistanceMetric alpha = DistanceMetric::L2SQ, class Pruner = ADSamplingPruner<q>>
 class PDXearch {
 public:
 	using DISTANCES_TYPE = DistanceType_t<q>;
@@ -169,7 +169,7 @@ protected:
 		std::vector<float> distances_to_centroids;
 		distances_to_centroids.resize(data.num_clusters);
 		for (size_t cluster_idx = 0; cluster_idx < data.num_clusters; cluster_idx++) {
-			distances_to_centroids[cluster_idx] = DistanceComputer<L2, F32>::Horizontal(
+			distances_to_centroids[cluster_idx] = DistanceComputer<DistanceMetric::L2SQ, F32>::Horizontal(
 			    query, data.centroids.get() + cluster_idx * data.num_dimensions, data.num_dimensions, nullptr);
 		}
 		clusters_indices.resize(data.num_clusters);

--- a/src/include/pdxearch/pdxearch.hpp
+++ b/src/include/pdxearch/pdxearch.hpp
@@ -29,8 +29,7 @@ public:
 	Pruner &pruner;
 	INDEX_TYPE &pdx_data;
 
-	PDXearch(INDEX_TYPE &data_index, Pruner &pruner)
-	    : pruner(pruner), pdx_data(data_index){
+	PDXearch(INDEX_TYPE &data_index, Pruner &pruner) : pruner(pruner), pdx_data(data_index) {
 		indices_dimensions.resize(pdx_data.num_dimensions);
 		cluster_indices_in_access_order.resize(pdx_data.num_clusters);
 		cluster_offsets.resize(pdx_data.num_clusters);
@@ -216,8 +215,8 @@ protected:
 			    std::min(current_dimension_idx + DIMENSIONS_FETCHING_SIZES[cur_subgrouping_size_idx],
 			             pdx_data.num_vertical_dimensions);
 			DistanceComputer<alpha, Q>::Vertical(query, data, n_vectors, n_vectors, current_dimension_idx,
-													last_dimension_to_fetch, pruning_distances, pruning_positions,
-													indices_dimensions.data(), dim_clip_value, nullptr);
+			                                     last_dimension_to_fetch, pruning_distances, pruning_positions,
+			                                     indices_dimensions.data(), dim_clip_value, nullptr);
 			current_dimension_idx = last_dimension_to_fetch;
 			cur_subgrouping_size_idx += 1;
 			GetPruningThreshold<Q>(k, heap, pruning_threshold, current_dimension_idx);
@@ -268,10 +267,10 @@ protected:
 			cur_n_vectors_not_pruned = n_vectors_not_pruned;
 			size_t last_dimension_to_test_idx =
 			    std::min(current_vertical_dimension + H_DIM_SIZE, (size_t)pdx_data.num_vertical_dimensions);
-			DistanceComputer<alpha, Q>::VerticalPruning(
-				query, data, cur_n_vectors_not_pruned, n_vectors, current_vertical_dimension,
-				last_dimension_to_test_idx, pruning_distances, pruning_positions, indices_dimensions.data(),
-				dim_clip_value, nullptr);
+			DistanceComputer<alpha, Q>::VerticalPruning(query, data, cur_n_vectors_not_pruned, n_vectors,
+			                                            current_vertical_dimension, last_dimension_to_test_idx,
+			                                            pruning_distances, pruning_positions, indices_dimensions.data(),
+			                                            dim_clip_value, nullptr);
 			current_dimension_idx = std::min(current_dimension_idx + H_DIM_SIZE, (size_t)pdx_data.num_dimensions);
 			current_vertical_dimension =
 			    std::min((uint32_t)(current_vertical_dimension + H_DIM_SIZE), pdx_data.num_vertical_dimensions);
@@ -328,8 +327,8 @@ public:
 
 		cluster_indices_in_access_order_offset = 0; // Reset cluster index offset for new search.
 		if constexpr (q == U8) {
-			quantizer.PrepareQuery(preprocessed_query, pdx_data.for_base, pdx_data.scale_factor,
-			                       dim_clip_value, quantized_query_buf);
+			quantizer.PrepareQuery(preprocessed_query, pdx_data.for_base, pdx_data.scale_factor, dim_clip_value,
+			                       quantized_query_buf);
 			this->prepared_query = quantized_query_buf;
 		} else {
 			this->prepared_query = preprocessed_query;
@@ -356,8 +355,8 @@ public:
 			const CLUSTER_TYPE &cluster = pdx_data.clusters[current_cluster_idx];
 
 			Warmup(prepared_query, cluster.data, cluster.num_embeddings, k, selectivity_threshold, pruning_positions,
-			       pruning_distances, pruning_threshold, *best_k, current_dimension_idx,
-			       n_vectors_not_pruned, dim_clip_value);
+			       pruning_distances, pruning_threshold, *best_k, current_dimension_idx, n_vectors_not_pruned,
+			       dim_clip_value);
 			Prune(prepared_query, cluster.data, cluster.num_embeddings, k, pruning_positions, pruning_distances,
 			      pruning_threshold, *best_k, current_dimension_idx, n_vectors_not_pruned, dim_clip_value);
 			if (n_vectors_not_pruned) {
@@ -395,9 +394,8 @@ public:
 			const CLUSTER_TYPE &cluster = pdx_data.clusters[current_cluster_idx];
 
 			Warmup<q, true>(prepared_query, cluster.data, cluster.num_embeddings, k, selectivity_threshold,
-			                pruning_positions, pruning_distances, pruning_threshold, *best_k,
-			                current_dimension_idx, n_vectors_not_pruned, dim_clip_value,
-			                passing_tuples, selection_vector);
+			                pruning_positions, pruning_distances, pruning_threshold, *best_k, current_dimension_idx,
+			                n_vectors_not_pruned, dim_clip_value, passing_tuples, selection_vector);
 			Prune(prepared_query, cluster.data, cluster.num_embeddings, k, pruning_positions, pruning_distances,
 			      pruning_threshold, *best_k, current_dimension_idx, n_vectors_not_pruned, dim_clip_value);
 			if (n_vectors_not_pruned) {
@@ -532,8 +530,8 @@ public:
 		alignas(64) QUANTIZED_VECTOR_TYPE local_quantized_query[PDX_MAX_DIMS];
 		QUANTIZED_VECTOR_TYPE *local_prepared_query;
 		if constexpr (q == U8) {
-			quantizer.PrepareQuery(query, pdx_data.for_base, pdx_data.scale_factor,
-			                       local_dim_clip_value, local_quantized_query);
+			quantizer.PrepareQuery(query, pdx_data.for_base, pdx_data.scale_factor, local_dim_clip_value,
+			                       local_quantized_query);
 			local_prepared_query = local_quantized_query;
 		} else {
 			local_prepared_query = query;
@@ -551,13 +549,13 @@ public:
 			CLUSTER_TYPE &cluster = pdx_data.clusters[current_cluster_idx];
 			if (local_heap.size() < k) {
 				// We cannot prune until we fill the heap
-				Start(local_prepared_query, cluster.data, cluster.num_embeddings, k, cluster.indices,
-				      pruning_positions, pruning_distances, local_heap, local_dim_clip_value);
+				Start(local_prepared_query, cluster.data, cluster.num_embeddings, k, cluster.indices, pruning_positions,
+				      pruning_distances, local_heap, local_dim_clip_value);
 				continue;
 			}
 			Warmup(local_prepared_query, cluster.data, cluster.num_embeddings, k, selectivity_threshold,
-			       pruning_positions, pruning_distances, pruning_threshold, local_heap,
-			       current_dimension_idx, n_vectors_not_pruned, local_dim_clip_value);
+			       pruning_positions, pruning_distances, pruning_threshold, local_heap, current_dimension_idx,
+			       n_vectors_not_pruned, local_dim_clip_value);
 			Prune(local_prepared_query, cluster.data, cluster.num_embeddings, k, pruning_positions, pruning_distances,
 			      pruning_threshold, local_heap, current_dimension_idx, n_vectors_not_pruned, local_dim_clip_value);
 			if (n_vectors_not_pruned) {
@@ -593,8 +591,8 @@ public:
 		alignas(64) QUANTIZED_VECTOR_TYPE local_quantized_query[PDX_MAX_DIMS];
 		QUANTIZED_VECTOR_TYPE *local_prepared_query;
 		if constexpr (q == U8) {
-			quantizer.PrepareQuery(query, pdx_data.for_base, pdx_data.scale_factor,
-			                       local_dim_clip_value, local_quantized_query);
+			quantizer.PrepareQuery(query, pdx_data.for_base, pdx_data.scale_factor, local_dim_clip_value,
+			                       local_quantized_query);
 			local_prepared_query = local_quantized_query;
 		} else {
 			local_prepared_query = query;
@@ -618,14 +616,13 @@ public:
 			if (local_heap.size() < k) {
 				// We cannot prune until we fill the heap
 				FilteredStart(local_prepared_query, cluster.data, cluster.num_embeddings, k, cluster.indices,
-				              pruning_positions, pruning_distances, local_heap, local_dim_clip_value,
-				              selection_vector, passing_tuples);
+				              pruning_positions, pruning_distances, local_heap, local_dim_clip_value, selection_vector,
+				              passing_tuples);
 				continue;
 			}
 			Warmup<q, true>(local_prepared_query, cluster.data, cluster.num_embeddings, k, selectivity_threshold,
-			                pruning_positions, pruning_distances, pruning_threshold, local_heap,
-			                current_dimension_idx, n_vectors_not_pruned, local_dim_clip_value,
-			                passing_tuples, selection_vector);
+			                pruning_positions, pruning_distances, pruning_threshold, local_heap, current_dimension_idx,
+			                n_vectors_not_pruned, local_dim_clip_value, passing_tuples, selection_vector);
 			Prune(local_prepared_query, cluster.data, cluster.num_embeddings, k, pruning_positions, pruning_distances,
 			      pruning_threshold, local_heap, current_dimension_idx, n_vectors_not_pruned, local_dim_clip_value);
 			if (n_vectors_not_pruned) {

--- a/src/include/pdxearch/pruners/adsampling.hpp
+++ b/src/include/pdxearch/pruners/adsampling.hpp
@@ -1,5 +1,4 @@
-#ifndef PDX_ADSAMPLING_U8_HPP
-#define PDX_ADSAMPLING_U8_HPP
+#pragma once
 
 #include <Eigen/Dense>
 #include <queue>
@@ -126,5 +125,3 @@ private:
 };
 
 } // namespace PDX
-
-#endif // PDX_ADSAMPLING_U8_HPP

--- a/src/include/pdxearch/quantizers/global.h
+++ b/src/include/pdxearch/quantizers/global.h
@@ -50,8 +50,8 @@ public:
 
 	uint8_t MAX_VALUE;
 
-	void PrepareQuery(const float *query, const float for_base, const float scale_factor,
-	                  int32_t *dim_clip_value, QUANTIZED_QUERY_TYPE *quantized_query) {
+	void PrepareQuery(const float *query, const float for_base, const float scale_factor, int32_t *dim_clip_value,
+	                  QUANTIZED_QUERY_TYPE *quantized_query) {
 		for (size_t i = 0; i < num_dimensions; ++i) {
 			// Scale factor is global in symmetric kernel
 			int rounded = static_cast<int>(std::round((query[i] - for_base) * scale_factor));

--- a/src/include/pdxearch/quantizers/global.h
+++ b/src/include/pdxearch/quantizers/global.h
@@ -10,6 +10,8 @@ namespace PDX {
 class Quantizer {
 
 public:
+	explicit Quantizer(size_t num_dimensions) : num_dimensions(num_dimensions) {
+	}
 	virtual ~Quantizer() = default;
 
 public:
@@ -28,11 +30,7 @@ public:
 			out[i] = src[i] / norm;
 		}
 	}
-	size_t num_dimensions = 0;
-
-	void SetD(size_t d) {
-		num_dimensions = d;
-	}
+	const size_t num_dimensions;
 
 	virtual void ScaleQuery(const float *src, int32_t *dst) {};
 };
@@ -42,7 +40,7 @@ class Global8Quantizer : public Quantizer {
 public:
 	using QUANTIZED_QUERY_TYPE = QuantizedVectorType_t<q>;
 
-	Global8Quantizer() {
+	explicit Global8Quantizer(size_t num_dimensions) : Quantizer(num_dimensions) {
 		if constexpr (q == Quantization::U8) {
 			MAX_VALUE = 255;
 		}

--- a/src/include/pdxearch/quantizers/global.h
+++ b/src/include/pdxearch/quantizers/global.h
@@ -1,5 +1,4 @@
-#ifndef PDX_QUANTIZERS_H
-#define PDX_QUANTIZERS_H
+#pragma once
 
 #include <cstdint>
 #include <cstdio>
@@ -42,8 +41,6 @@ template <Quantization q = U8>
 class Global8Quantizer : public Quantizer {
 public:
 	using QUANTIZED_QUERY_TYPE = QuantizedVectorType_t<q>;
-	alignas(64) inline static int32_t dim_clip_value[4096];
-	alignas(64) inline static QUANTIZED_QUERY_TYPE quantized_query[4096];
 
 	Global8Quantizer() {
 		if constexpr (q == Quantization::U8) {
@@ -53,7 +50,8 @@ public:
 
 	uint8_t MAX_VALUE;
 
-	void PrepareQuery(const float *query, const float for_base, const float scale_factor) {
+	void PrepareQuery(const float *query, const float for_base, const float scale_factor,
+	                  int32_t *dim_clip_value, QUANTIZED_QUERY_TYPE *quantized_query) {
 		for (size_t i = 0; i < num_dimensions; ++i) {
 			// Scale factor is global in symmetric kernel
 			int rounded = static_cast<int>(std::round((query[i] - for_base) * scale_factor));
@@ -68,5 +66,3 @@ public:
 };
 
 }; // namespace PDX
-
-#endif // PDX_QUANTIZERS_H


### PR DESCRIPTION
## Improvements
- Removing static variables in `pdxearch.hpp` class
- Removing redundant GetClustersAccessOrderIVF method
- Using modern guards rather than ifdef
- Removing `DimensionsOrder` logic
- Removing `*Vectorized` functions that are not used anymore
- Removing `DistanceFunction` in favor of `DistanceMetric` enum