### PR TITLE
Removing Dimensionality Limits and Unused Code

### DIFF
--- a/src/include/index/pdxearch_index_utils.hpp
+++ b/src/include/index/pdxearch_index_utils.hpp
@@ -6,7 +6,7 @@
 #include "duckdb/storage/storage_info.hpp"
 #include "pdxearch/common.hpp"
 #include "pdxearch/index_base/pdx_ivf.hpp"
-#include "pdxearch/quantizers/global.h"
+#include "pdxearch/quantizers/global.hpp"
 #include "pdxearch/pruners/adsampling.hpp"
 
 namespace duckdb {

--- a/src/include/index/pdxearch_kmeans.hpp
+++ b/src/include/index/pdxearch_kmeans.hpp
@@ -63,8 +63,6 @@ struct KMeansResult {
 	// Extract assignments
 	for (uint64_t cluster_idx = 0; cluster_idx < num_clusters; cluster_idx++) {
 		const size_t cluster_size = faiss_index.invlists->list_size(cluster_idx);
-		D_ASSERT(0 < cluster_size);
-		D_ASSERT(cluster_size <= PDX::MAX_EMBEDDINGS_PER_CLUSTER);
 		result.assignments[cluster_idx].reserve(cluster_size);
 
 		const faiss::idx_t *faiss_ids = faiss_index.invlists->get_ids(cluster_idx);

--- a/src/include/index/pdxearch_wrapper.hpp
+++ b/src/include/index/pdxearch_wrapper.hpp
@@ -163,8 +163,12 @@ public:
 		// Row-major buffer that the current cluster's embeddings are "gathered" into. This buffer is the source for
 		// StoreClusterEmbeddings, the result of which is persistently stored in the index. The buffer is reused across
 		// clusters.
+		size_t max_cluster_size = 0;
+		for (size_t i = 0; i < num_clusters_per_row_group; i++) {
+			max_cluster_size = std::max(max_cluster_size, kmeans_result.assignments[i].size());
+		}
 		std::unique_ptr<float[]> tmp_cluster_embeddings =
-		    std::make_unique<float[]>(static_cast<uint64_t>(PDX::MAX_EMBEDDINGS_PER_CLUSTER * num_dimensions));
+		    std::make_unique<float[]>(static_cast<uint64_t>(max_cluster_size * num_dimensions));
 
 		// Set up the IVF clusters' metadata and store the embeddings.
 		for (size_t cluster_idx = 0; cluster_idx < num_clusters_per_row_group; cluster_idx++) {
@@ -284,8 +288,12 @@ public:
 		// Row-major buffer that the current cluster's embeddings are "gathered" into. This buffer is the source for
 		// StoreClusterEmbeddings, the result of which is persistently stored in the index. The buffer is reused across
 		// clusters.
+		size_t max_cluster_size = 0;
+		for (size_t i = 0; i < num_clusters; i++) {
+			max_cluster_size = std::max(max_cluster_size, kmeans_result.assignments[i].size());
+		}
 		std::unique_ptr<float[]> tmp_cluster_embeddings =
-		    std::make_unique<float[]>(static_cast<uint64_t>(PDX::MAX_EMBEDDINGS_PER_CLUSTER * index->num_dimensions));
+		    std::make_unique<float[]>(static_cast<uint64_t>(max_cluster_size * index->num_dimensions));
 
 		// Set up the IVF clusters' metadata and store the embeddings.
 		for (size_t cluster_idx = 0; cluster_idx < num_clusters; cluster_idx++) {

--- a/src/include/pdxearch/common.hpp
+++ b/src/include/pdxearch/common.hpp
@@ -11,8 +11,6 @@ static constexpr float PROPORTION_HORIZONTAL_DIM = 0.75f;
 static constexpr size_t D_THRESHOLD_FOR_DCT_ROTATION = 512;
 static constexpr size_t PDX_VECTOR_SIZE = 64;
 static constexpr size_t PDX_MAX_DIMS = 65536;
-static constexpr size_t MAX_EMBEDDINGS_PER_CLUSTER = 10240;
-
 static constexpr size_t H_DIM_SIZE = 64;
 static constexpr uint32_t DIMENSIONS_FETCHING_SIZES[24] = {4,  4,  8,  8,   8,   16,  16,  32,  32,  32,  32,   64,
                                                            64, 64, 64, 128, 128, 128, 128, 256, 256, 512, 1024, 2048};

--- a/src/include/pdxearch/common.hpp
+++ b/src/include/pdxearch/common.hpp
@@ -108,7 +108,7 @@ struct PDXDimensionSplit {
 	if (num_dimensions <= 128) {
 		local_proportion_horizontal_dim = 0.25;
 	}
-	auto horizontal_d = static_cast<uint32_t>(num_dimensions * local_proportion_horizontal_dim);
+	auto horizontal_d = static_cast<uint32_t>(static_cast<float>(num_dimensions) * local_proportion_horizontal_dim);
 	auto vertical_d = static_cast<uint32_t>(num_dimensions - horizontal_d);
 	if (horizontal_d % H_DIM_SIZE > 0) {
 		horizontal_d = ((horizontal_d + H_DIM_SIZE / 2) / H_DIM_SIZE) * H_DIM_SIZE;

--- a/src/include/pdxearch/common.hpp
+++ b/src/include/pdxearch/common.hpp
@@ -7,7 +7,7 @@
 
 namespace PDX {
 
-static constexpr float PROPORTION_VERTICAL_DIM = 0.25;
+static constexpr float PROPORTION_HORIZONTAL_DIM = 0.75f;
 static constexpr size_t D_THRESHOLD_FOR_DCT_ROTATION = 512;
 static constexpr size_t PDX_VECTOR_SIZE = 64;
 static constexpr size_t PDX_MAX_DIMS = 4096;
@@ -108,31 +108,28 @@ struct PDXDimensionSplit {
 };
 
 [[nodiscard]] static inline constexpr PDXDimensionSplit GetPDXDimensionSplit(const uint32_t num_dimensions) {
-	// Based on the original PDX code (see link) but with PROPORTION_VERTICAL_DIM fixed (in the original code the
-	// constant represents the horizontal, not the vertical portion):
-	// https://github.com/cwida/PDX/blob/4a2e65e90e177155c42d277b5523c4fd2fa35540/python/pdxearch/index_base.py#L119-L127
-
-	assert(num_dimensions % 4 == 0);
-	assert(num_dimensions >= PDX_MIN_DIMS);
-	assert(num_dimensions <= PDX_MAX_DIMS);
-
-	// Special case for 128 dimensions, to avoid {128, 0} split.
-	if (num_dimensions == 128) {
-		return {64, 64};
+	auto local_proportion_horizontal_dim = PROPORTION_HORIZONTAL_DIM;
+	if (num_dimensions <= 128) {
+		local_proportion_horizontal_dim = 0.25;
+	}
+	auto horizontal_d = static_cast<uint32_t>(num_dimensions * local_proportion_horizontal_dim);
+	auto vertical_d = static_cast<uint32_t>(num_dimensions - horizontal_d);
+	if (horizontal_d % H_DIM_SIZE > 0) {
+		horizontal_d = ((horizontal_d + H_DIM_SIZE / 2) / H_DIM_SIZE) * H_DIM_SIZE;
+		vertical_d = num_dimensions - horizontal_d;
+	}
+	if (!vertical_d) {
+		horizontal_d = H_DIM_SIZE;
+		vertical_d = num_dimensions - horizontal_d;
+	}
+	if (num_dimensions <= H_DIM_SIZE) {
+		horizontal_d = 0;
+		vertical_d = num_dimensions;
 	}
 
-	uint32_t v_dims = static_cast<uint32_t>(static_cast<float>(num_dimensions) * PDX::PROPORTION_VERTICAL_DIM);
-	uint32_t h_dims = num_dimensions - v_dims;
+	assert(horizontal_d + vertical_d == num_dimensions);
 
-	// Round the horizontal dimensions to the nearest multiple of PDX_VECTOR_SIZE.
-	if (h_dims % PDX_VECTOR_SIZE != 0) {
-		h_dims = ((h_dims + PDX_VECTOR_SIZE / 2) / PDX_VECTOR_SIZE) * PDX_VECTOR_SIZE;
-		v_dims = num_dimensions - h_dims;
-	}
-
-	assert(h_dims + v_dims == num_dimensions);
-
-	return {h_dims, v_dims};
+	return {horizontal_d, vertical_d};
 };
 
 static_assert(GetPDXDimensionSplit(128).horizontal_dimensions == 64);

--- a/src/include/pdxearch/common.hpp
+++ b/src/include/pdxearch/common.hpp
@@ -11,8 +11,8 @@ static constexpr float PROPORTION_HORIZONTAL_DIM = 0.75f;
 static constexpr size_t D_THRESHOLD_FOR_DCT_ROTATION = 512;
 static constexpr size_t PDX_MAX_DIMS = 65536;
 static constexpr size_t H_DIM_SIZE = 64;
-static constexpr uint32_t DIMENSIONS_FETCHING_SIZES[24] = {4,  4,  8,  8,   8,   16,  16,  32,  32,  32,  32,   64,
-                                                           64, 64, 64, 128, 128, 128, 128, 256, 256, 512, 1024, 2048};
+static constexpr uint32_t DIMENSIONS_FETCHING_SIZES[20] = {16,  16,  32,  32,  32,  32,  64,  64,   64,   64,
+                                                           128, 128, 128, 128, 256, 256, 512, 1024, 2048, 65536};
 
 template <class T, T val = 8>
 static constexpr uint32_t AlignValue(T n) {
@@ -128,6 +128,24 @@ struct PDXDimensionSplit {
 	return {horizontal_d, vertical_d};
 };
 
+static_assert(GetPDXDimensionSplit(4).horizontal_dimensions == 0);
+static_assert(GetPDXDimensionSplit(4).vertical_dimensions == 4);
+
+static_assert(GetPDXDimensionSplit(33).horizontal_dimensions == 0);
+static_assert(GetPDXDimensionSplit(33).vertical_dimensions == 33);
+
+static_assert(GetPDXDimensionSplit(64).horizontal_dimensions == 0);
+static_assert(GetPDXDimensionSplit(64).vertical_dimensions == 64);
+
+static_assert(GetPDXDimensionSplit(65).horizontal_dimensions == 0);
+static_assert(GetPDXDimensionSplit(65).vertical_dimensions == 65);
+
+static_assert(GetPDXDimensionSplit(100).horizontal_dimensions == 0);
+static_assert(GetPDXDimensionSplit(100).vertical_dimensions == 100);
+
+static_assert(GetPDXDimensionSplit(127).horizontal_dimensions == 0);
+static_assert(GetPDXDimensionSplit(127).vertical_dimensions == 127);
+
 static_assert(GetPDXDimensionSplit(128).horizontal_dimensions == 64);
 static_assert(GetPDXDimensionSplit(128).vertical_dimensions == 64);
 
@@ -140,4 +158,4 @@ static_assert(GetPDXDimensionSplit(1024).vertical_dimensions == 256);
 static_assert(GetPDXDimensionSplit(1028).horizontal_dimensions == 768);
 static_assert(GetPDXDimensionSplit(1028).vertical_dimensions == 260);
 
-}; // namespace PDX
+} // namespace PDX

--- a/src/include/pdxearch/common.hpp
+++ b/src/include/pdxearch/common.hpp
@@ -10,8 +10,7 @@ namespace PDX {
 static constexpr float PROPORTION_HORIZONTAL_DIM = 0.75f;
 static constexpr size_t D_THRESHOLD_FOR_DCT_ROTATION = 512;
 static constexpr size_t PDX_VECTOR_SIZE = 64;
-static constexpr size_t PDX_MAX_DIMS = 4096;
-static constexpr size_t PDX_MIN_DIMS = 128;
+static constexpr size_t PDX_MAX_DIMS = 65536;
 static constexpr size_t MAX_EMBEDDINGS_PER_CLUSTER = 10240;
 
 static constexpr size_t H_DIM_SIZE = 64;

--- a/src/include/pdxearch/common.hpp
+++ b/src/include/pdxearch/common.hpp
@@ -9,7 +9,6 @@ namespace PDX {
 
 static constexpr float PROPORTION_HORIZONTAL_DIM = 0.75f;
 static constexpr size_t D_THRESHOLD_FOR_DCT_ROTATION = 512;
-static constexpr size_t PDX_VECTOR_SIZE = 64;
 static constexpr size_t PDX_MAX_DIMS = 65536;
 static constexpr size_t H_DIM_SIZE = 64;
 static constexpr uint32_t DIMENSIONS_FETCHING_SIZES[24] = {4,  4,  8,  8,   8,   16,  16,  32,  32,  32,  32,   64,

--- a/src/include/pdxearch/distance_computers/avx2_computers.hpp
+++ b/src/include/pdxearch/distance_computers/avx2_computers.hpp
@@ -21,39 +21,21 @@ public:
 
 	alignas(64) static DISTANCE_TYPE pruning_distances_tmp[4096];
 
-	// Defer to the scalar kernel
-	template <bool USE_DIMENSIONS_REORDER, bool SKIP_PRUNED>
-	static void VerticalPruning(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
-	                            size_t total_vectors, size_t start_dimension, size_t end_dimension,
-	                            DISTANCE_TYPE *distances_p, const uint32_t *pruning_positions = nullptr,
-	                            const uint32_t *indices_dimensions = nullptr, const int32_t *dim_clip_value = nullptr) {
+	template <bool SKIP_PRUNED>
+	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
+	                     size_t total_vectors, size_t start_dimension, size_t end_dimension,
+	                     DISTANCE_TYPE *distances_p, const uint32_t *pruning_positions = nullptr,
+	                     const int32_t *dim_clip_value = nullptr) {
 		size_t dimensions_jump_factor = total_vectors;
 		for (size_t dimension_idx = start_dimension; dimension_idx < end_dimension; ++dimension_idx) {
-			uint32_t true_dimension_idx = dimension_idx;
-			if constexpr (USE_DIMENSIONS_REORDER) {
-				true_dimension_idx = indices_dimensions[dimension_idx];
-			}
-			size_t offset_to_dimension_start = true_dimension_idx * dimensions_jump_factor;
+			size_t offset_to_dimension_start = dimension_idx * dimensions_jump_factor;
 			for (size_t vector_idx = 0; vector_idx < n_vectors; ++vector_idx) {
 				auto true_vector_idx = vector_idx;
 				if constexpr (SKIP_PRUNED) {
 					true_vector_idx = pruning_positions[vector_idx];
 				}
-				float to_multiply = query[true_dimension_idx] - data[offset_to_dimension_start + true_vector_idx];
+				float to_multiply = query[dimension_idx] - data[offset_to_dimension_start + true_vector_idx];
 				distances_p[true_vector_idx] += to_multiply * to_multiply;
-			}
-		}
-	}
-
-	// Defer to the scalar kernel
-	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t start_dimension,
-	                     size_t end_dimension, DISTANCE_TYPE *distances_p) {
-		for (size_t dim_idx = start_dimension; dim_idx < end_dimension; dim_idx++) {
-			size_t dimension_idx = dim_idx;
-			size_t offset_to_dimension_start = dimension_idx * PDX_VECTOR_SIZE;
-			for (size_t vector_idx = 0; vector_idx < PDX_VECTOR_SIZE; ++vector_idx) {
-				float to_multiply = query[dimension_idx] - data[offset_to_dimension_start + vector_idx];
-				distances_p[vector_idx] += to_multiply * to_multiply;
 			}
 		}
 	}

--- a/src/include/pdxearch/distance_computers/avx2_computers.hpp
+++ b/src/include/pdxearch/distance_computers/avx2_computers.hpp
@@ -23,9 +23,8 @@ public:
 
 	template <bool SKIP_PRUNED>
 	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
-	                     size_t total_vectors, size_t start_dimension, size_t end_dimension,
-	                     DISTANCE_TYPE *distances_p, const uint32_t *pruning_positions = nullptr,
-	                     const int32_t *dim_clip_value = nullptr) {
+	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, DISTANCE_TYPE *distances_p,
+	                     const uint32_t *pruning_positions = nullptr, const int32_t *dim_clip_value = nullptr) {
 		size_t dimensions_jump_factor = total_vectors;
 		for (size_t dimension_idx = start_dimension; dimension_idx < end_dimension; ++dimension_idx) {
 			size_t offset_to_dimension_start = dimension_idx * dimensions_jump_factor;

--- a/src/include/pdxearch/distance_computers/avx512_computers.hpp
+++ b/src/include/pdxearch/distance_computers/avx512_computers.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <cstdio>
 #include <cassert>
 #include <immintrin.h>
 #include "pdxearch/common.hpp"
@@ -20,81 +19,10 @@ public:
 	using DATA_TYPE = DataType_t<F32>;
 	using scalar_computer = ScalarComputer<DistanceMetric::L2SQ, Quantization::F32>;
 
-	alignas(64) static DISTANCE_TYPE pruning_distances_tmp[4096];
-
-	static void GatherDistances(size_t n_vectors, DISTANCE_TYPE *distances_p, const uint32_t *pruning_positions) {
-		for (size_t vector_idx = 0; vector_idx < n_vectors; ++vector_idx) {
-			auto true_vector_idx = pruning_positions[vector_idx];
-			pruning_distances_tmp[vector_idx] = distances_p[true_vector_idx];
-		}
-	}
-
-	static void GatherBasedKernel(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data,
-	                              size_t n_vectors, size_t total_vectors, size_t start_dimension, size_t end_dimension,
-	                              DISTANCE_TYPE *distances_p, const uint32_t *pruning_positions = nullptr,
-	                              const int32_t *dim_clip_value = nullptr) {
-		GatherDistances(n_vectors, distances_p, pruning_positions);
-		__m512 data_vec, d_vec, cur_dist_vec;
-		__m256 data_vec_m256, d_vec_m256, cur_dist_vec_m256;
-		// Then we move data to be sequential
-		size_t dimensions_jump_factor = total_vectors;
-		for (size_t dimension_idx = start_dimension; dimension_idx < end_dimension; ++dimension_idx) {
-			__m512 query_vec;
-			query_vec = _mm512_set1_ps(query[dimension_idx]);
-			size_t offset_to_dimension_start = dimension_idx * dimensions_jump_factor;
-			const float *tmp_data = data + offset_to_dimension_start;
-			// Now we do the sequential distance calculation loop which would use SIMD
-			// Up to 16
-			size_t i = 0;
-			for (; i + 16 < n_vectors; i += 16) {
-				cur_dist_vec = _mm512_load_ps(&pruning_distances_tmp[i]);
-				data_vec =
-				    _mm512_i32gather_ps(_mm512_load_epi32(&pruning_positions[i]), tmp_data, sizeof(DISTANCE_TYPE));
-				d_vec = _mm512_sub_ps(data_vec, query_vec);
-				cur_dist_vec = _mm512_fmadd_ps(d_vec, d_vec, cur_dist_vec);
-				_mm512_store_ps(&pruning_distances_tmp[i], cur_dist_vec);
-			}
-			__m256 query_vec_m256;
-			query_vec_m256 = _mm256_set1_ps(query[dimension_idx]);
-			// Up to 8
-			for (; i + 8 < n_vectors; i += 8) {
-				cur_dist_vec_m256 = _mm256_load_ps(&pruning_distances_tmp[i]);
-				data_vec_m256 =
-				    _mm256_i32gather_ps(tmp_data, _mm256_load_epi32(&pruning_positions[i]), sizeof(DISTANCE_TYPE));
-				d_vec_m256 = _mm256_sub_ps(data_vec_m256, query_vec_m256);
-				cur_dist_vec_m256 = _mm256_fmadd_ps(d_vec_m256, d_vec_m256, cur_dist_vec_m256);
-				_mm256_store_ps(&pruning_distances_tmp[i], cur_dist_vec_m256);
-			}
-			// Tail
-			for (; i < n_vectors; i++) {
-				float to_multiply = query[dimension_idx] - tmp_data[pruning_positions[i]];
-				pruning_distances_tmp[i] += to_multiply * to_multiply;
-			}
-		}
-		// We now move distances back
-		for (size_t vector_idx = 0; vector_idx < n_vectors; ++vector_idx) {
-			auto true_vector_idx = pruning_positions[vector_idx];
-			distances_p[true_vector_idx] = pruning_distances_tmp[vector_idx];
-		}
-	}
-
 	template <bool SKIP_PRUNED>
 	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
 	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, DISTANCE_TYPE *distances_p,
 	                     const uint32_t *pruning_positions = nullptr, const int32_t *dim_clip_value = nullptr) {
-		// SIMD is less efficient when looping on the array of not-yet pruned vectors
-		// A way to improve the performance by ~20% is using a GATHER intrinsic. However this only works on Intel
-		// microarchs. In AMD (Zen 4, Zen 3) using a GATHER is shooting ourselves in the foot (~80 uops)
-		// __AVX512FP16__ macro let us detect Intel architectures (from Sapphire Rapids onwards)
-#if false && defined(__AVX512FP16__)
-        if (n_vectors >= 8) {
-            GatherBasedKernel(
-                    query, data, n_vectors, total_vectors, start_dimension, end_dimension,
-                    distances_p, pruning_positions
-            );
-            return;
-        }
-#endif
 		size_t dimensions_jump_factor = total_vectors;
 		for (size_t dimension_idx = start_dimension; dimension_idx < end_dimension; ++dimension_idx) {
 			size_t offset_to_dimension_start = dimension_idx * dimensions_jump_factor;
@@ -103,7 +31,7 @@ public:
 				if constexpr (SKIP_PRUNED) {
 					true_vector_idx = pruning_positions[vector_idx];
 				}
-				float to_multiply = query[dimension_idx] - data[offset_to_dimension_start + true_vector_idx];
+				DISTANCE_TYPE to_multiply = query[dimension_idx] - data[offset_to_dimension_start + true_vector_idx];
 				distances_p[true_vector_idx] += to_multiply * to_multiply;
 			}
 		}

--- a/src/include/pdxearch/distance_computers/avx512_computers.hpp
+++ b/src/include/pdxearch/distance_computers/avx512_computers.hpp
@@ -29,28 +29,19 @@ public:
 		}
 	}
 
-	template <bool USE_DIMENSIONS_REORDER>
 	static void GatherBasedKernel(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data,
 	                              size_t n_vectors, size_t total_vectors, size_t start_dimension, size_t end_dimension,
 	                              DISTANCE_TYPE *distances_p, const uint32_t *pruning_positions = nullptr,
-	                              const uint32_t *indices_dimensions = nullptr, const int32_t *dim_clip_value = nullptr,
-	                              const float *scaling_factors = nullptr) {
+	                              const int32_t *dim_clip_value = nullptr) {
 		GatherDistances(n_vectors, distances_p, pruning_positions);
 		__m512 data_vec, d_vec, cur_dist_vec;
 		__m256 data_vec_m256, d_vec_m256, cur_dist_vec_m256;
 		// Then we move data to be sequential
 		size_t dimensions_jump_factor = total_vectors;
 		for (size_t dimension_idx = start_dimension; dimension_idx < end_dimension; ++dimension_idx) {
-			uint32_t true_dimension_idx = dimension_idx;
-			if constexpr (USE_DIMENSIONS_REORDER) {
-				true_dimension_idx = indices_dimensions[dimension_idx];
-			}
 			__m512 query_vec;
-			query_vec = _mm512_set1_ps(query[true_dimension_idx]);
-			//            if constexpr (L_ALPHA == IP){
-			//                query_vec = _mm512_set1_ps(-2 * query[true_dimension_idx]);
-			//            }
-			size_t offset_to_dimension_start = true_dimension_idx * dimensions_jump_factor;
+			query_vec = _mm512_set1_ps(query[dimension_idx]);
+			size_t offset_to_dimension_start = dimension_idx * dimensions_jump_factor;
 			const float *tmp_data = data + offset_to_dimension_start;
 			// Now we do the sequential distance calculation loop which would use SIMD
 			// Up to 16
@@ -64,10 +55,7 @@ public:
 				_mm512_store_ps(&pruning_distances_tmp[i], cur_dist_vec);
 			}
 			__m256 query_vec_m256;
-			query_vec_m256 = _mm256_set1_ps(query[true_dimension_idx]);
-			//            if constexpr (L_ALPHA == IP){
-			//                query_vec_m256 = _mm256_set1_ps(-2 * query[true_dimension_idx]);
-			//            }
+			query_vec_m256 = _mm256_set1_ps(query[dimension_idx]);
 			// Up to 8
 			for (; i + 8 < n_vectors; i += 8) {
 				cur_dist_vec_m256 = _mm256_load_ps(&pruning_distances_tmp[i]);
@@ -79,7 +67,7 @@ public:
 			}
 			// Tail
 			for (; i < n_vectors; i++) {
-				float to_multiply = query[true_dimension_idx] - tmp_data[pruning_positions[i]];
+				float to_multiply = query[dimension_idx] - tmp_data[pruning_positions[i]];
 				pruning_distances_tmp[i] += to_multiply * to_multiply;
 			}
 		}
@@ -90,53 +78,34 @@ public:
 		}
 	}
 
-	// Defer to the scalar kernel
-	template <bool USE_DIMENSIONS_REORDER, bool SKIP_PRUNED>
-	static void VerticalPruning(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
-	                            size_t total_vectors, size_t start_dimension, size_t end_dimension,
-	                            DISTANCE_TYPE *distances_p, const uint32_t *pruning_positions = nullptr,
-	                            const uint32_t *indices_dimensions = nullptr, const int32_t *dim_clip_value = nullptr,
-	                            const float *scaling_factors = nullptr) {
+	template <bool SKIP_PRUNED>
+	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
+	                     size_t total_vectors, size_t start_dimension, size_t end_dimension,
+	                     DISTANCE_TYPE *distances_p, const uint32_t *pruning_positions = nullptr,
+	                     const int32_t *dim_clip_value = nullptr) {
 		// SIMD is less efficient when looping on the array of not-yet pruned vectors
 		// A way to improve the performance by ~20% is using a GATHER intrinsic. However this only works on Intel
 		// microarchs. In AMD (Zen 4, Zen 3) using a GATHER is shooting ourselves in the foot (~80 uops)
 		// __AVX512FP16__ macro let us detect Intel architectures (from Sapphire Rapids onwards)
 #if false && defined(__AVX512FP16__)
         if (n_vectors >= 8) {
-            GatherBasedKernel<USE_DIMENSIONS_REORDER>(
+            GatherBasedKernel(
                     query, data, n_vectors, total_vectors, start_dimension, end_dimension,
-                    distances_p, pruning_positions, indices_dimensions
+                    distances_p, pruning_positions
             );
             return;
         }
 #endif
 		size_t dimensions_jump_factor = total_vectors;
 		for (size_t dimension_idx = start_dimension; dimension_idx < end_dimension; ++dimension_idx) {
-			uint32_t true_dimension_idx = dimension_idx;
-			if constexpr (USE_DIMENSIONS_REORDER) {
-				true_dimension_idx = indices_dimensions[dimension_idx];
-			}
-			size_t offset_to_dimension_start = true_dimension_idx * dimensions_jump_factor;
+			size_t offset_to_dimension_start = dimension_idx * dimensions_jump_factor;
 			for (size_t vector_idx = 0; vector_idx < n_vectors; ++vector_idx) {
 				auto true_vector_idx = vector_idx;
 				if constexpr (SKIP_PRUNED) {
 					true_vector_idx = pruning_positions[vector_idx];
 				}
-				float to_multiply = query[true_dimension_idx] - data[offset_to_dimension_start + true_vector_idx];
+				float to_multiply = query[dimension_idx] - data[offset_to_dimension_start + true_vector_idx];
 				distances_p[true_vector_idx] += to_multiply * to_multiply;
-			}
-		}
-	}
-
-	// Defer to the scalar kernel
-	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t start_dimension,
-	                     size_t end_dimension, DISTANCE_TYPE *distances_p, const float *scaling_factors = nullptr) {
-		for (size_t dim_idx = start_dimension; dim_idx < end_dimension; dim_idx++) {
-			size_t dimension_idx = dim_idx;
-			size_t offset_to_dimension_start = dimension_idx * PDX_VECTOR_SIZE;
-			for (size_t vector_idx = 0; vector_idx < PDX_VECTOR_SIZE; ++vector_idx) {
-				float to_multiply = query[dimension_idx] - data[offset_to_dimension_start + vector_idx];
-				distances_p[vector_idx] += to_multiply * to_multiply;
 			}
 		}
 	}
@@ -147,7 +116,7 @@ public:
 		__m512 a_vec, b_vec;
 	simsimd_l2sq_f32_skylake_cycle:
 		if (num_dimensions < 16) {
-			__mmask16 mask = (__mmask16)_bzhi_u32(0xFFFFFFFF, num_dimensions);
+			__mmask16 mask = static_cast<__mmask16>(_bzhi_u32(0xFFFFFFFF, num_dimensions));
 			a_vec = _mm512_maskz_loadu_ps(mask, vector1);
 			b_vec = _mm512_maskz_loadu_ps(mask, vector2);
 			num_dimensions = 0;

--- a/src/include/pdxearch/distance_computers/avx512_computers.hpp
+++ b/src/include/pdxearch/distance_computers/avx512_computers.hpp
@@ -80,9 +80,8 @@ public:
 
 	template <bool SKIP_PRUNED>
 	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
-	                     size_t total_vectors, size_t start_dimension, size_t end_dimension,
-	                     DISTANCE_TYPE *distances_p, const uint32_t *pruning_positions = nullptr,
-	                     const int32_t *dim_clip_value = nullptr) {
+	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, DISTANCE_TYPE *distances_p,
+	                     const uint32_t *pruning_positions = nullptr, const int32_t *dim_clip_value = nullptr) {
 		// SIMD is less efficient when looping on the array of not-yet pruned vectors
 		// A way to improve the performance by ~20% is using a GATHER intrinsic. However this only works on Intel
 		// microarchs. In AMD (Zen 4, Zen 3) using a GATHER is shooting ourselves in the foot (~80 uops)

--- a/src/include/pdxearch/distance_computers/base_computers.hpp
+++ b/src/include/pdxearch/distance_computers/base_computers.hpp
@@ -35,12 +35,9 @@ class DistanceComputer<DistanceMetric::L2SQ, Quantization::F32> {
 #endif
 
 public:
-	constexpr static auto VerticalReorderedPruning = computer::VerticalPruning<true, true>;
-	constexpr static auto VerticalPruning = computer::VerticalPruning<false, true>;
-	constexpr static auto VerticalReordered = computer::VerticalPruning<true, false>;
-	constexpr static auto Vertical = computer::VerticalPruning<false, false>;
+	constexpr static auto VerticalPruning = computer::Vertical<true>;
+	constexpr static auto Vertical = computer::Vertical<false>;
 
-	constexpr static auto VerticalBlock = computer::Vertical;
 	constexpr static auto Horizontal = computer::Horizontal;
 };
 

--- a/src/include/pdxearch/distance_computers/base_computers.hpp
+++ b/src/include/pdxearch/distance_computers/base_computers.hpp
@@ -41,4 +41,4 @@ public:
 	constexpr static auto Horizontal = computer::Horizontal;
 };
 
-}; // namespace PDX
+} // namespace PDX

--- a/src/include/pdxearch/distance_computers/neon_computers.hpp
+++ b/src/include/pdxearch/distance_computers/neon_computers.hpp
@@ -17,40 +17,21 @@ public:
 	using QUERY_TYPE = QuantizedVectorType_t<F32>;
 	using DATA_TYPE = DataType_t<F32>;
 
-	// Defer to the scalar kernel
-	template <bool USE_DIMENSIONS_REORDER, bool SKIP_PRUNED>
-	static void VerticalPruning(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
-	                            size_t total_vectors, size_t start_dimension, size_t end_dimension,
-	                            DISTANCE_TYPE *distances_p, const uint32_t *pruning_positions,
-	                            const uint32_t *indices_dimensions, const int32_t *dim_clip_value,
-	                            const float *scaling_factors) {
+	template <bool SKIP_PRUNED>
+	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
+	                     size_t total_vectors, size_t start_dimension, size_t end_dimension,
+	                     DISTANCE_TYPE *distances_p, const uint32_t *pruning_positions,
+	                     const int32_t *dim_clip_value) {
 		size_t dimensions_jump_factor = total_vectors;
 		for (size_t dimension_idx = start_dimension; dimension_idx < end_dimension; ++dimension_idx) {
-			uint32_t true_dimension_idx = dimension_idx;
-			if constexpr (USE_DIMENSIONS_REORDER) {
-				true_dimension_idx = indices_dimensions[dimension_idx];
-			}
-			size_t offset_to_dimension_start = true_dimension_idx * dimensions_jump_factor;
+			size_t offset_to_dimension_start = dimension_idx * dimensions_jump_factor;
 			for (size_t vector_idx = 0; vector_idx < n_vectors; ++vector_idx) {
 				auto true_vector_idx = vector_idx;
 				if constexpr (SKIP_PRUNED) {
 					true_vector_idx = pruning_positions[vector_idx];
 				}
-				float to_multiply = query[true_dimension_idx] - data[offset_to_dimension_start + true_vector_idx];
+				float to_multiply = query[dimension_idx] - data[offset_to_dimension_start + true_vector_idx];
 				distances_p[true_vector_idx] += to_multiply * to_multiply;
-			}
-		}
-	}
-
-	// Defer to the scalar kernel
-	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t start_dimension,
-	                     size_t end_dimension, DISTANCE_TYPE *distances_p, const float *scaling_factors) {
-		for (size_t dim_idx = start_dimension; dim_idx < end_dimension; dim_idx++) {
-			size_t dimension_idx = dim_idx;
-			size_t offset_to_dimension_start = dimension_idx * PDX_VECTOR_SIZE;
-			for (size_t vector_idx = 0; vector_idx < PDX_VECTOR_SIZE; ++vector_idx) {
-				float to_multiply = query[dimension_idx] - data[offset_to_dimension_start + vector_idx];
-				distances_p[vector_idx] += to_multiply * to_multiply;
 			}
 		}
 	}

--- a/src/include/pdxearch/distance_computers/neon_computers.hpp
+++ b/src/include/pdxearch/distance_computers/neon_computers.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <cstdio>
 #include "arm_neon.h"
 #include "pdxearch/common.hpp"
 
@@ -29,7 +28,7 @@ public:
 				if constexpr (SKIP_PRUNED) {
 					true_vector_idx = pruning_positions[vector_idx];
 				}
-				float to_multiply = query[dimension_idx] - data[offset_to_dimension_start + true_vector_idx];
+				DISTANCE_TYPE to_multiply = query[dimension_idx] - data[offset_to_dimension_start + true_vector_idx];
 				distances_p[true_vector_idx] += to_multiply * to_multiply;
 			}
 		}
@@ -38,10 +37,10 @@ public:
 	static DISTANCE_TYPE Horizontal(const QUERY_TYPE *__restrict vector1, const DATA_TYPE *__restrict vector2,
 	                                size_t num_dimensions, const float *scaling_factors = nullptr) {
 #if defined(__APPLE__)
-		float distance = 0.0;
+		DISTANCE_TYPE distance = 0.0;
 #pragma clang loop vectorize(enable)
 		for (size_t i = 0; i < num_dimensions; ++i) {
-			float diff = vector1[i] - vector2[i];
+			DISTANCE_TYPE diff = vector1[i] - vector2[i];
 			distance += diff * diff;
 		}
 		return distance;
@@ -56,7 +55,7 @@ public:
 		}
 		DISTANCE_TYPE distance = vaddvq_f32(sum_vec);
 		for (; i < num_dimensions; ++i) {
-			float diff = vector1[i] - vector2[i];
+			DISTANCE_TYPE diff = vector1[i] - vector2[i];
 			distance += diff * diff;
 		}
 		return distance;

--- a/src/include/pdxearch/distance_computers/neon_computers.hpp
+++ b/src/include/pdxearch/distance_computers/neon_computers.hpp
@@ -19,9 +19,8 @@ public:
 
 	template <bool SKIP_PRUNED>
 	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
-	                     size_t total_vectors, size_t start_dimension, size_t end_dimension,
-	                     DISTANCE_TYPE *distances_p, const uint32_t *pruning_positions,
-	                     const int32_t *dim_clip_value) {
+	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, DISTANCE_TYPE *distances_p,
+	                     const uint32_t *pruning_positions, const int32_t *dim_clip_value) {
 		size_t dimensions_jump_factor = total_vectors;
 		for (size_t dimension_idx = start_dimension; dimension_idx < end_dimension; ++dimension_idx) {
 			size_t offset_to_dimension_start = dimension_idx * dimensions_jump_factor;

--- a/src/include/pdxearch/distance_computers/scalar_computers.hpp
+++ b/src/include/pdxearch/distance_computers/scalar_computers.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <cstdio>
 #include "pdxearch/common.hpp"
 
 namespace PDX {
@@ -37,6 +36,7 @@ public:
 	static DISTANCE_TYPE Horizontal(const QUERY_TYPE *__restrict vector1, const DATA_TYPE *__restrict vector2,
 	                                size_t num_dimensions, const float *scaling_factors = nullptr) {
 		DISTANCE_TYPE distance = 0.0;
+#pragma clang loop vectorize(enable)
 		for (size_t dimension_idx = 0; dimension_idx < num_dimensions; ++dimension_idx) {
 			DISTANCE_TYPE to_multiply = vector1[dimension_idx] - vector2[dimension_idx];
 			distance += to_multiply * to_multiply;

--- a/src/include/pdxearch/distance_computers/scalar_computers.hpp
+++ b/src/include/pdxearch/distance_computers/scalar_computers.hpp
@@ -18,9 +18,8 @@ public:
 
 	template <bool SKIP_PRUNED>
 	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
-	                     size_t total_vectors, size_t start_dimension, size_t end_dimension,
-	                     DISTANCE_TYPE *distances_p, const uint32_t *pruning_positions = nullptr,
-	                     const int32_t *dim_clip_value = nullptr) {
+	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, DISTANCE_TYPE *distances_p,
+	                     const uint32_t *pruning_positions = nullptr, const int32_t *dim_clip_value = nullptr) {
 		size_t dimensions_jump_factor = total_vectors;
 		for (size_t dimension_idx = start_dimension; dimension_idx < end_dimension; ++dimension_idx) {
 			size_t offset_to_dimension_start = dimension_idx * dimensions_jump_factor;
@@ -29,8 +28,7 @@ public:
 				if constexpr (SKIP_PRUNED) {
 					true_vector_idx = pruning_positions[vector_idx];
 				}
-				DISTANCE_TYPE to_multiply =
-				    query[dimension_idx] - data[offset_to_dimension_start + true_vector_idx];
+				DISTANCE_TYPE to_multiply = query[dimension_idx] - data[offset_to_dimension_start + true_vector_idx];
 				distances_p[true_vector_idx] += to_multiply * to_multiply;
 			}
 		}

--- a/src/include/pdxearch/distance_computers/scalar_computers.hpp
+++ b/src/include/pdxearch/distance_computers/scalar_computers.hpp
@@ -16,45 +16,22 @@ public:
 	using QUERY_TYPE = QuantizedVectorType_t<F32>;
 	using DATA_TYPE = DataType_t<F32>;
 
-	// Defer to the scalar kernel
-	template <bool USE_DIMENSIONS_REORDER, bool SKIP_PRUNED>
-	static void VerticalPruning(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
-	                            size_t total_vectors, size_t start_dimension, size_t end_dimension,
-	                            DISTANCE_TYPE *distances_p, const uint32_t *pruning_positions = nullptr,
-	                            const uint32_t *indices_dimensions = nullptr, const int32_t *dim_clip_value = nullptr,
-	                            const float *scaling_factors = nullptr) {
+	template <bool SKIP_PRUNED>
+	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
+	                     size_t total_vectors, size_t start_dimension, size_t end_dimension,
+	                     DISTANCE_TYPE *distances_p, const uint32_t *pruning_positions = nullptr,
+	                     const int32_t *dim_clip_value = nullptr) {
 		size_t dimensions_jump_factor = total_vectors;
 		for (size_t dimension_idx = start_dimension; dimension_idx < end_dimension; ++dimension_idx) {
-			uint32_t true_dimension_idx = dimension_idx;
-			if constexpr (USE_DIMENSIONS_REORDER) {
-				true_dimension_idx = indices_dimensions[dimension_idx];
-			}
-			size_t offset_to_dimension_start = true_dimension_idx * dimensions_jump_factor;
+			size_t offset_to_dimension_start = dimension_idx * dimensions_jump_factor;
 			for (size_t vector_idx = 0; vector_idx < n_vectors; ++vector_idx) {
 				auto true_vector_idx = vector_idx;
 				if constexpr (SKIP_PRUNED) {
 					true_vector_idx = pruning_positions[vector_idx];
 				}
 				DISTANCE_TYPE to_multiply =
-				    query[true_dimension_idx] - data[offset_to_dimension_start + true_vector_idx];
+				    query[dimension_idx] - data[offset_to_dimension_start + true_vector_idx];
 				distances_p[true_vector_idx] += to_multiply * to_multiply;
-			}
-		}
-	}
-
-	// Defer to the scalar kernel
-	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t start_dimension,
-	                     size_t end_dimension, DISTANCE_TYPE *distances_p, const float *scaling_factors = nullptr) {
-		for (size_t dim_idx = start_dimension; dim_idx < end_dimension; dim_idx++) {
-			size_t dimension_idx = dim_idx;
-			size_t offset_to_dimension_start = dimension_idx * PDX_VECTOR_SIZE;
-			for (size_t vector_idx = 0; vector_idx < PDX_VECTOR_SIZE; ++vector_idx) {
-				DISTANCE_TYPE to_multiply = query[dimension_idx] - data[offset_to_dimension_start + vector_idx];
-				distances_p[vector_idx] += to_multiply * to_multiply;
-				//                if constexpr (L_ALPHA == IP){
-				//                    distances_p[vector_idx] -= 2 * query[dimension_idx] *
-				//                    data[offset_to_dimension_start + vector_idx];
-				//                }
 			}
 		}
 	}

--- a/src/include/pdxearch/index_base/pdx_ivf.hpp
+++ b/src/include/pdxearch/index_base/pdx_ivf.hpp
@@ -22,14 +22,13 @@ public:
 	const uint32_t num_vertical_dimensions {};
 	const uint32_t num_horizontal_dimensions {};
 	std::vector<CLUSTER_TYPE> clusters;
-	const bool is_ivf {};
 	const bool is_normalized {};
 	std::unique_ptr<float[]> centroids {};
 
 	IndexPDXIVF(uint32_t num_dimensions, uint64_t total_num_embeddings, uint32_t num_clusters, bool is_normalized)
 	    : num_dimensions(num_dimensions), total_num_embeddings(total_num_embeddings), num_clusters(num_clusters),
 	      num_vertical_dimensions(GetPDXDimensionSplit(num_dimensions).vertical_dimensions),
-	      num_horizontal_dimensions(GetPDXDimensionSplit(num_dimensions).horizontal_dimensions), is_ivf(true),
+	      num_horizontal_dimensions(GetPDXDimensionSplit(num_dimensions).horizontal_dimensions),
 	      is_normalized(is_normalized) {
 		clusters.reserve(num_clusters);
 	}

--- a/src/include/pdxearch/pdxearch.hpp
+++ b/src/include/pdxearch/pdxearch.hpp
@@ -459,7 +459,6 @@ public:
 	                   const int32_t *dim_clip_value, uint8_t *selection_vector, uint32_t passing_tuples) {
 		ResetPruningDistances<Q>(n_vectors, pruning_distances);
 		size_t n_vectors_not_pruned = 0;
-		DistanceType_t<Q> pruning_threshold = std::numeric_limits<DistanceType_t<Q>>::max();
 		float selection_percentage = (static_cast<float>(passing_tuples) / static_cast<float>(n_vectors));
 		InitPositionsArrayFromSelectionVector<Q>(n_vectors, n_vectors_not_pruned, pruning_positions, selection_vector);
 		// Always start with horizontal block, regardless of selectivity

--- a/src/include/pdxearch/pruners/adsampling.hpp
+++ b/src/include/pdxearch/pruners/adsampling.hpp
@@ -88,7 +88,7 @@ public:
 	}
 
 private:
-	float epsilon0 = 2.1;
+	float epsilon0 = 1.5;
 	Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> matrix;
 	std::vector<float> ratios;
 
@@ -96,7 +96,7 @@ private:
 		if (visited_dimensions == 0) {
 			return 1;
 		}
-		if (visited_dimensions == static_cast<int>(num_dimensions)) {
+		if (visited_dimensions == num_dimensions) {
 			return 1.0;
 		}
 		return static_cast<float>(visited_dimensions) / num_dimensions *

--- a/src/include/pdxearch/quantizers/global.hpp
+++ b/src/include/pdxearch/quantizers/global.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <cstdio>
 #include <cmath>
 #include "pdxearch/common.hpp"
 
@@ -31,8 +30,6 @@ public:
 		}
 	}
 	const size_t num_dimensions;
-
-	virtual void ScaleQuery(const float *src, int32_t *dst) {};
 };
 
 template <Quantization q = U8>
@@ -41,12 +38,9 @@ public:
 	using QUANTIZED_QUERY_TYPE = QuantizedVectorType_t<q>;
 
 	explicit Global8Quantizer(size_t num_dimensions) : Quantizer(num_dimensions) {
-		if constexpr (q == Quantization::U8) {
-			MAX_VALUE = 255;
-		}
 	}
 
-	uint8_t MAX_VALUE;
+	uint8_t MAX_VALUE = 255;
 
 	void PrepareQuery(const float *query, const float for_base, const float scale_factor, int32_t *dim_clip_value,
 	                  QUANTIZED_QUERY_TYPE *quantized_query) {
@@ -63,4 +57,4 @@ public:
 	};
 };
 
-}; // namespace PDX
+} // namespace PDX

--- a/src/index/create/pdxearch_index_create_plan.cpp
+++ b/src/index/create/pdxearch_index_create_plan.cpp
@@ -84,8 +84,9 @@ PhysicalOperator &PDXearchIndex::CreatePlan(PlanIndexInput &input) {
 
 	const auto arr_dims = ArrayType::GetSize(arr_type);
 	if (arr_dims > PDX::PDX_MAX_DIMS) {
-		throw BinderException("PDXearch index FLOAT array length (i.e., dimensions) must be lower than %d, got %d",
-		                      PDX::PDX_MAX_DIMS, arr_dims);
+		throw BinderException(
+		    "PDXearch index FLOAT array length (i.e., dimensions) must be less than or equal to %d, got %d",
+		    PDX::PDX_MAX_DIMS, arr_dims);
 	}
 
 	// Projection to execute expressions on the key columns

--- a/src/index/create/pdxearch_index_create_plan.cpp
+++ b/src/index/create/pdxearch_index_create_plan.cpp
@@ -86,10 +86,9 @@ PhysicalOperator &PDXearchIndex::CreatePlan(PlanIndexInput &input) {
 	// https://github.com/cwida/PDX/blob/91618e01e574e594e27c71abfe3b1d5094657d53/python/pdxearch/index_base.py#L201-L204
 	// The maximum constraint is because of PDX_MAX_DIMS use in pdxearch.hpp.
 	const auto arr_dims = ArrayType::GetSize(arr_type);
-	if (arr_dims < PDX::PDX_MIN_DIMS || arr_dims > PDX::PDX_MAX_DIMS || arr_dims % 4 != 0) {
-		throw BinderException("PDXearch index FLOAT array length (i.e., dimensions) must be between %d and %d "
-		                      "(inclusive), and be divisible by 4, got %d",
-		                      PDX::PDX_MIN_DIMS, PDX::PDX_MAX_DIMS, arr_dims);
+	if (arr_dims > PDX::PDX_MAX_DIMS) {
+		throw BinderException("PDXearch index FLOAT array length (i.e., dimensions) must be lower than %d, got %d",
+		                      PDX::PDX_MAX_DIMS, arr_dims);
 	}
 
 	// Projection to execute expressions on the key columns

--- a/src/index/create/pdxearch_index_create_plan.cpp
+++ b/src/index/create/pdxearch_index_create_plan.cpp
@@ -82,9 +82,6 @@ PhysicalOperator &PDXearchIndex::CreatePlan(PlanIndexInput &input) {
 		throw BinderException("PDXearch index key type must be FLOAT");
 	}
 
-	// The minimum and "divisible by 4" constraints are inherent to PDXearch:
-	// https://github.com/cwida/PDX/blob/91618e01e574e594e27c71abfe3b1d5094657d53/python/pdxearch/index_base.py#L201-L204
-	// The maximum constraint is because of PDX_MAX_DIMS use in pdxearch.hpp.
 	const auto arr_dims = ArrayType::GetSize(arr_type);
 	if (arr_dims > PDX::PDX_MAX_DIMS) {
 		throw BinderException("PDXearch index FLOAT array length (i.e., dimensions) must be lower than %d, got %d",

--- a/test/sql/create/index_create_validate_column.test
+++ b/test/sql/create/index_create_validate_column.test
@@ -68,6 +68,6 @@ INSERT INTO t1 SELECT i + 1 as id, list_transform(range(${dims}), x -> random())
 statement error
 CREATE INDEX t1_idx ON t1 USING PDXEARCH (emb);
 ----
-<REGEX>:Binder Error: PDXearch index FLOAT array length \(i\.e\., dimensions\) must be lower than 65536, got .*
+<REGEX>:Binder Error: PDXearch index FLOAT array length \(i\.e\., dimensions\) must be less than or equal to 65536, got .*
 
 endloop

--- a/test/sql/create/index_create_validate_column.test
+++ b/test/sql/create/index_create_validate_column.test
@@ -57,17 +57,17 @@ endloop
 # Invalid number of dimensions
 # ============================================
 
-foreach dims 127 129 4097
+foreach dims 65537 70000
 
 statement ok
 CREATE OR REPLACE TABLE t1 (id INTEGER, emb FLOAT[${dims}]);
 
 statement ok
-INSERT INTO t1 SELECT i + 1 as id, list_transform(range(${dims}), x -> random()) FROM range(10000) t(i);
+INSERT INTO t1 SELECT i + 1 as id, list_transform(range(${dims}), x -> random()) FROM range(1000) t(i);
 
 statement error
 CREATE INDEX t1_idx ON t1 USING PDXEARCH (emb);
 ----
-<REGEX>:Binder Error: PDXearch index FLOAT array length .* must be between .* and .* \(inclusive\), and be divisible by 4, got .*
+<REGEX>:Binder Error: PDXearch index FLOAT array length \(i\.e\., dimensions\) must be lower than 65536, got .*
 
 endloop

--- a/test/sql/filtered_search/index_filtered_scan_k.test
+++ b/test/sql/filtered_search/index_filtered_scan_k.test
@@ -5,27 +5,22 @@
 # TODO: Update this test to take dynamic n_probe into account. Need to decide on
 # the desired behavior and implement it first.
 
-# TODO: Fix bug with line 65+ in this file when sift-128 is used. Use the following statements just like the other tests:
-#       Once fixed, also add the cosine and IP metrics below.
-# require parquet
-# test-env DIMS 128
-# test-env QUERY_EMB [0,16,35,5,32,31,14,10,11,78,55,10,45,83,11,6,14,57,102,75,20,8,3,5,67,17,19,26,5,0,1,22,60,26,7,1,18,22,84,53,85,119,119,4,24,18,7,7,1,81,106,102,72,30,6,0,9,1,9,119,72,1,4,33,119,29,6,1,0,1,14,52,119,30,3,0,0,55,92,111,2,5,4,9,22,89,96,14,1,0,1,82,59,16,20,5,25,14,11,4,0,0,1,26,47,23,4,0,0,4,38,83,30,14,9,4,9,17,23,41,0,0,2,8,19,25,23,1]
-# INSERT INTO t1 FROM read_parquet('test/assets/sift-128-euclidean-245760.parquet') LIMIT ${NUM_ROWS};
-# statement ok
-# CREATE OR REPLACE TABLE t2 AS SELECT * FROM t1 WHERE id < ${predicate_threshold}
-#     ORDER BY ${distance_func}(emb, ${QUERY_EMB}::FLOAT[${DIMS}]) LIMIT ${LIMIT};
+statement ok
+SET late_materialization_max_rows = 0;
+
+require parquet
 
 require pdxearch
 
 # Variables
-test-env DIMS 512
+test-env DIMS 128
 
 test-env NUM_ROWS 20000
 
+test-env QUERY_EMB [0,16,35,5,32,31,14,10,11,78,55,10,45,83,11,6,14,57,102,75,20,8,3,5,67,17,19,26,5,0,1,22,60,26,7,1,18,22,84,53,85,119,119,4,24,18,7,7,1,81,106,102,72,30,6,0,9,1,9,119,72,1,4,33,119,29,6,1,0,1,14,52,119,30,3,0,0,55,92,111,2,5,4,9,22,89,96,14,1,0,1,82,59,16,20,5,25,14,11,4,0,0,1,26,47,23,4,0,0,4,38,83,30,14,9,4,9,17,23,41,0,0,2,8,19,25,23,1]
+
 # N_PROBE is set to 0 to ensure an exact search (probing all clusters).
 test-env N_PROBE 0
-
-test-env QUERY_VEC 1000.51
 
 test-env LIMIT 50
 
@@ -34,7 +29,7 @@ statement ok
 CREATE TABLE t1 (id INTEGER, emb FLOAT[${DIMS}]);
 
 statement ok
-INSERT INTO t1 (id, emb) SELECT i as id, repeat([i], ${DIMS}) FROM range(${NUM_ROWS}) t(i);
+INSERT INTO t1 FROM read_parquet('test/assets/sift-128-euclidean-245760.parquet') LIMIT ${NUM_ROWS};
 
 # Create copy of table without index for verification.
 statement ok
@@ -56,7 +51,7 @@ foreach predicate_threshold 50 51 100 500
 
 statement ok
 CREATE OR REPLACE TABLE t2 AS SELECT * FROM t1 WHERE id < ${predicate_threshold}
-    ORDER BY ${distance_func}(emb, repeat([${QUERY_VEC}], ${DIMS})::FLOAT[${DIMS}]) LIMIT ${LIMIT};
+    ORDER BY ${distance_func}(emb, ${QUERY_EMB}::FLOAT[${DIMS}]) LIMIT ${LIMIT};
 
 query I
 SELECT (SELECT COUNT(*) FROM t2) = ${LIMIT};
@@ -73,7 +68,7 @@ foreach predicate_threshold 0 1 5 25 49
 
 statement ok
 CREATE OR REPLACE TABLE t2 AS SELECT * FROM t1 WHERE id < ${predicate_threshold}
-    ORDER BY ${distance_func}(emb, repeat([${QUERY_VEC}], ${DIMS})::FLOAT[${DIMS}]) LIMIT ${LIMIT};
+   ORDER BY ${distance_func}(emb, ${QUERY_EMB}::FLOAT[${DIMS}]) LIMIT ${LIMIT};
 
 query I
 SELECT (SELECT COUNT(*) FROM t2) = ${predicate_threshold};


### PR DESCRIPTION
## Critical Fixes
- Fixed bug when `DIMS = 128`.

## Improvements 
- Refactored `PDXDimensionSplit` function. No longer needed that `dimensionality % 4 == 0`. PDX works with arbitrary dimensions. 
- Removed limits of `MIN` and `MAX` dimensions. PDX supports any dimensionality. 
  - When dimensionality is less than 64, only horizontal dimensions are used (no pruning). 
  - We have left a `PDX_MAX_DIMS` check in the `pdxearch_index_create_plan` of 65536 just for the sake of it. 
  - Buffers that were previously allocated with `PDX_MAX_DIMS` are now allocated in the constructor as std::vector.
- Removing unused functions in `distance_computers`.
- Removed `PDX_VECTOR_SIZE` (not used anymore and we will not use it in the future either).
- Removing completely `DIMENSIONS_REORDERING` logic, as we are not going to use this now or in the future.
- Removing completely `MAX_EMBEDDINGS_PER_CLUSTER`. We now support clusters of arbitrary sizes.
  - PDXearch constructor detects the size of the largest cluster to allocate memory once with this amount of values when we receive a query. 
- Adapted test cases to changes

## Let op!
- We should support empty clusters. Either skipping them, or not storing them in the PDX structure at all. I believe the latter would be ideal and we can do this in the pdxearch_wrapper.hpp just by skipping the empty ones and reducing num_clusters by the empty ones? Or maybe its better to skip them during a search. 
