### PR TITLE
Address clang-tidy warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,13 @@ endif()
 find_package(OpenMP REQUIRED)
 find_package(Eigen3 REQUIRED)
 
+# Remove OpenMP dependency for CI clang-tidy job. This workaround can be removed if we remove our Eigen dependency.
+# Defining EIGEN_DONT_PARALLELIZE prevents Eigen from including the <omp.h>, which the clang-tidy CI is not properly set
+# up to use. The CI's build and test job will ensure the extension remains buildable across platforms and architectures.
+if(CLANG_TIDY)
+  add_definitions(-DEIGEN_DONT_PARALLELIZE)
+endif()
+
 set(FAISS_ENABLE_GPU OFF)
 set(FAISS_ENABLE_PYTHON OFF)
 set(BUILD_TESTING OFF)

--- a/src/include/index/search/pdxearch_index_filtered_scan_logical.hpp
+++ b/src/include/index/search/pdxearch_index_filtered_scan_logical.hpp
@@ -10,7 +10,7 @@ class DuckTableEntry;
 class LogicalPDXearchIndexFilteredScan : public LogicalExtensionOperator {
 public:
 	LogicalPDXearchIndexFilteredScan(DuckTableEntry &table, Index &index, idx_t limit,
-	                                 unsafe_unique_array<float> &&query_vector, vector<ColumnIndex> column_ids,
+	                                 unsafe_unique_array<float> query_vector, vector<ColumnIndex> column_ids,
 	                                 idx_t table_index)
 	    : LogicalExtensionOperator(), column_ids(std::move(column_ids)), table_index(table_index), table(table),
 	      index(index), limit(limit), query_embedding(std::move(query_vector)) {

--- a/src/include/index/search/pdxearch_index_scan_logical.hpp
+++ b/src/include/index/search/pdxearch_index_scan_logical.hpp
@@ -10,7 +10,7 @@ class DuckTableEntry;
 class LogicalPDXearchIndexScan : public LogicalExtensionOperator {
 public:
 	LogicalPDXearchIndexScan(DuckTableEntry &table, Index &index, idx_t limit,
-	                         unsafe_unique_array<float> &&query_embedding, vector<ColumnIndex> column_ids,
+	                         unsafe_unique_array<float> query_embedding, vector<ColumnIndex> column_ids,
 	                         idx_t table_index)
 	    : LogicalExtensionOperator(), column_ids(std::move(column_ids)), table_index(table_index), table(table),
 	      index(index), limit(limit), query_embedding(std::move(query_embedding)) {

--- a/src/include/pdxearch/pdxearch.hpp
+++ b/src/include/pdxearch/pdxearch.hpp
@@ -48,7 +48,7 @@ public:
 	BuildResultSetFromHeap(uint32_t k,
 	                       std::priority_queue<KNNCandidate_t, std::vector<KNNCandidate_t>, VectorComparator_t> &heap) {
 		// Pop the initialization element from the heap, as it can't be part of the result.
-		if (heap.size() > 0 && heap.top().distance == std::numeric_limits<float>::max()) {
+		if (!heap.empty() && heap.top().distance == std::numeric_limits<float>::max()) {
 			heap.pop();
 		}
 


### PR DESCRIPTION
- Made changes to address warnings
- Remove OpenMP dependency for clang-tidy (locally and on CI)