### PR TITLE
Epsilon0 management, `num_clusters` fixed to 480, and `std::unique_ptr`

### DIFF
--- a/src/include/index/pdxearch_index_utils.hpp
+++ b/src/include/index/pdxearch_index_utils.hpp
@@ -107,9 +107,8 @@ private:
 	const size_t num_dimensions;
 
 public:
-	explicit EmbeddingPreprocessor(const size_t num_dimensions, const float *const rotation_matrix,
-	                               const float epsilon0)
-	    : pruner(num_dimensions, epsilon0, rotation_matrix), quantizer(num_dimensions), num_dimensions(num_dimensions) {
+	explicit EmbeddingPreprocessor(const size_t num_dimensions, const float *const rotation_matrix)
+	    : pruner(num_dimensions, rotation_matrix), quantizer(num_dimensions), num_dimensions(num_dimensions) {
 	}
 
 	// Warning: modifies the input_embedding.

--- a/src/include/index/pdxearch_wrapper.hpp
+++ b/src/include/index/pdxearch_wrapper.hpp
@@ -19,7 +19,6 @@ namespace duckdb {
 
 class PDXearchWrapper {
 public:
-	static constexpr float EPSILON0 = 1.5;
 	static constexpr PDX::DistanceMetric DEFAULT_DISTANCE_METRIC = PDX::DistanceMetric::L2SQ;
 	static constexpr PDX::Quantization DEFAULT_QUANTIZATION = PDX::Quantization::F32;
 	static constexpr int32_t DEFAULT_N_PROBE = 128;
@@ -151,7 +150,7 @@ public:
 
 		row_group.index = make_uniq<PDX::IndexPDXIVF<PDX::F32>>(num_dimensions, num_embeddings,
 		                                                        num_clusters_per_row_group, IsNormalized());
-		row_group.pruner = make_uniq<PDX::ADSamplingPruner<PDX::F32>>(num_dimensions, EPSILON0, rotation_matrix.get());
+		row_group.pruner = make_uniq<PDX::ADSamplingPruner<PDX::F32>>(num_dimensions, rotation_matrix.get());
 
 		// Compute K-means centroids and embedding-to-centroid assignment.
 		KMeansResult kmeans_result =
@@ -267,7 +266,7 @@ public:
 	      row_id_cluster_mapping(estimated_cardinality),
 	      index(make_uniq<PDX::IndexPDXIVF<PDX::F32>>(num_dimensions, estimated_cardinality, num_clusters,
 	                                                  IsNormalized())),
-	      pruner(make_uniq<PDX::ADSamplingPruner<PDX::F32>>(num_dimensions, EPSILON0, rotation_matrix.get())) {
+	      pruner(make_uniq<PDX::ADSamplingPruner<PDX::F32>>(num_dimensions, rotation_matrix.get())) {
 		// Additional constraints on the number of dimensions are enforced in `pdxearch_index_plan.cpp`.
 		D_ASSERT(num_dimensions > 0);
 		D_ASSERT(estimated_cardinality > 0);

--- a/src/include/index/pdxearch_wrapper.hpp
+++ b/src/include/index/pdxearch_wrapper.hpp
@@ -152,15 +152,14 @@ public:
 		D_ASSERT(num_dimensions > 0);
 		D_ASSERT(num_embeddings > 0);
 		D_ASSERT(num_clusters_per_row_group > 0);
+		// TODO(@lkuffo): See issue #38. num_embeddings < DEFAULT_N_CLUSTERS_PER_ROW_GROUP is currently not handled.
+		D_ASSERT(num_embeddings >= num_clusters_per_row_group);
 
 		row_group.index = make_uniq<PDX::IndexPDXIVF<PDX::F32>>(num_dimensions, num_embeddings,
 		                                                        num_clusters_per_row_group, IsNormalized());
 		row_group.pruner = make_uniq<PDX::ADSamplingPruner<PDX::F32>>(num_dimensions, rotation_matrix.get());
 
 		// Compute K-means centroids and embedding-to-centroid assignment.
-		// TODO(@lkuffo): What would happen if num_embeddings < num_clusters_per_row_group?
-		//     If this happens, I would like to set num_clusters_per_row_group to 1,
-		// 	   but I'm not sure if this will break something else
 		KMeansResult kmeans_result =
 		    ComputeKMeans(embeddings, num_embeddings, num_dimensions, num_clusters_per_row_group, GetDistanceMetric());
 

--- a/src/include/index/pdxearch_wrapper.hpp
+++ b/src/include/index/pdxearch_wrapper.hpp
@@ -23,10 +23,10 @@ public:
 	static constexpr PDX::Quantization DEFAULT_QUANTIZATION = PDX::Quantization::F32;
 	static constexpr int32_t DEFAULT_N_PROBE = 128;
 
-	// We aim for 1:256 ratio of clusters to embeddings
-	// As a DuckDB rowgroup size is 122880, we set 480 clusters per row group
-	// While some rowgroups might be smaller, 480 is still a good number, even
-	// if the rowgroup falls down to 40k embeddings
+	// We aim for a 1:256 ratio of clusters to embeddings. As a DuckDB rowgroup
+	// size is usually 122880, we set 480 clusters per row group. While some
+	// row groups might be smaller, 480 is still a good number, even if the
+	// row group falls down to 40k embeddings.
 	static constexpr size_t DEFAULT_N_CLUSTERS_PER_ROW_GROUP = 480;
 
 private:

--- a/src/include/index/pdxearch_wrapper.hpp
+++ b/src/include/index/pdxearch_wrapper.hpp
@@ -159,7 +159,7 @@ public:
 
 		// Compute K-means centroids and embedding-to-centroid assignment.
 		// TODO(@lkuffo): What would happen if num_embeddings < num_clusters_per_row_group?
-		//     If this happens, I would like to set num_clusters_per_row_group to 1, 
+		//     If this happens, I would like to set num_clusters_per_row_group to 1,
 		// 	   but I'm not sure if this will break something else
 		KMeansResult kmeans_result =
 		    ComputeKMeans(embeddings, num_embeddings, num_dimensions, num_clusters_per_row_group, GetDistanceMetric());

--- a/src/include/index/pdxearch_wrapper.hpp
+++ b/src/include/index/pdxearch_wrapper.hpp
@@ -23,12 +23,6 @@ public:
 	static constexpr PDX::Quantization DEFAULT_QUANTIZATION = PDX::Quantization::F32;
 	static constexpr int32_t DEFAULT_N_PROBE = 128;
 
-	// We aim for a 1:256 ratio of clusters to embeddings. As a DuckDB rowgroup
-	// size is usually 122880, we set 480 clusters per row group. While some
-	// row groups might be smaller, 480 is still a good number, even if the
-	// row group falls down to 40k embeddings.
-	static constexpr size_t DEFAULT_N_CLUSTERS_PER_ROW_GROUP = 480;
-
 private:
 	const uint32_t num_dimensions;
 	// Whether the embeddings (both the query embeddings and those stored in the
@@ -118,6 +112,13 @@ public:
 // group. This allows the creation of the index and searching in it to be parallelized at the row group level. This
 // wrapper only supports float32 quantization.
 class PDXearchWrapperF32 : public PDXearchWrapper {
+public:
+	// We aim for a 1:256 ratio of clusters to embeddings. As a DuckDB rowgroup
+	// size is usually 122880, we set 480 clusters per row group. While some
+	// row groups might be smaller, 480 is still a good number, even if the
+	// row group falls down to 40k embeddings.
+	static constexpr size_t DEFAULT_N_CLUSTERS_PER_ROW_GROUP = 480;
+
 private:
 	uint32_t num_clusters_per_row_group {};
 	std::vector<PDXRowGroup> row_groups;

--- a/src/include/pdxearch/common.hpp
+++ b/src/include/pdxearch/common.hpp
@@ -14,6 +14,9 @@ static constexpr size_t H_DIM_SIZE = 64;
 static constexpr uint32_t DIMENSIONS_FETCHING_SIZES[20] = {16,  16,  32,  32,  32,  32,  64,  64,   64,   64,
                                                            128, 128, 128, 128, 256, 256, 512, 1024, 2048, 65536};
 
+// Epsilon0 parameter of ADSampling (Reference: https://dl.acm.org/doi/abs/10.1145/3589282)
+static constexpr float ADSAMPLING_PRUNING_AGGRESIVENESS = 1.5f; 
+
 template <class T, T val = 8>
 static constexpr uint32_t AlignValue(T n) {
 	return ((n + (val - 1)) / val) * val;

--- a/src/include/pdxearch/common.hpp
+++ b/src/include/pdxearch/common.hpp
@@ -15,7 +15,7 @@ static constexpr uint32_t DIMENSIONS_FETCHING_SIZES[20] = {16,  16,  32,  32,  3
                                                            128, 128, 128, 128, 256, 256, 512, 1024, 2048, 65536};
 
 // Epsilon0 parameter of ADSampling (Reference: https://dl.acm.org/doi/abs/10.1145/3589282)
-static constexpr float ADSAMPLING_PRUNING_AGGRESIVENESS = 1.5f; 
+static constexpr float ADSAMPLING_PRUNING_AGGRESIVENESS = 1.5f;
 
 template <class T, T val = 8>
 static constexpr uint32_t AlignValue(T n) {

--- a/src/include/pdxearch/pdxearch.hpp
+++ b/src/include/pdxearch/pdxearch.hpp
@@ -31,14 +31,14 @@ public:
 
 	PDXearch(INDEX_TYPE &data_index, Pruner &pruner)
 	    : quantizer(data_index.num_dimensions), pruner(pruner), pdx_data(data_index),
+	      cluster_offsets(new size_t[data_index.num_clusters]),
+	      cluster_indices_in_access_order(new uint32_t[data_index.num_clusters]),
 	      dim_clip_value(new int32_t[data_index.num_dimensions]()),
 	      quantized_query_buf(new QUANTIZED_VECTOR_TYPE[data_index.num_dimensions]) {
-		cluster_indices_in_access_order.reset(new uint32_t[pdx_data.num_clusters]);
-		cluster_offsets.reset(new size_t[pdx_data.num_clusters]);
-		for (size_t i = 0; i < pdx_data.num_clusters; ++i) {
+		for (size_t i = 0; i < data_index.num_clusters; ++i) {
 			cluster_offsets[i] = total_embeddings;
-			total_embeddings += pdx_data.clusters[i].num_embeddings;
-			max_cluster_size = std::max(max_cluster_size, static_cast<size_t>(pdx_data.clusters[i].num_embeddings));
+			total_embeddings += data_index.clusters[i].num_embeddings;
+			max_cluster_size = std::max(max_cluster_size, static_cast<size_t>(data_index.clusters[i].num_embeddings));
 		}
 	}
 

--- a/src/include/pdxearch/pdxearch.hpp
+++ b/src/include/pdxearch/pdxearch.hpp
@@ -184,8 +184,7 @@ protected:
 			          });
 		} else {
 			std::partial_sort(clusters_indices, clusters_indices + static_cast<int64_t>(nprobe),
-			                  clusters_indices + data.num_clusters,
-			                  [&distances_to_centroids](size_t i1, size_t i2) {
+			                  clusters_indices + data.num_clusters, [&distances_to_centroids](size_t i1, size_t i2) {
 				                  return distances_to_centroids[i1] < distances_to_centroids[i2];
 			                  });
 		}
@@ -322,7 +321,8 @@ public:
 		this->k = k;
 		this->predicate_evaluator = std::move(predicate_evaluator);
 
-		GetClustersAccessOrderIVF(preprocessed_query, pdx_data, pdx_data.num_clusters, cluster_indices_in_access_order.get());
+		GetClustersAccessOrderIVF(preprocessed_query, pdx_data, pdx_data.num_clusters,
+		                          cluster_indices_in_access_order.get());
 
 		cluster_indices_in_access_order_offset = 0; // Reset cluster index offset for new search.
 		if constexpr (q == U8) {
@@ -357,8 +357,8 @@ public:
 			}
 
 			Warmup(prepared_query, cluster.data, cluster.num_embeddings, k, selectivity_threshold,
-			       pruning_positions.get(), pruning_distances.get(), pruning_threshold, *best_k,
-			       current_dimension_idx, n_vectors_not_pruned, dim_clip_value.get());
+			       pruning_positions.get(), pruning_distances.get(), pruning_threshold, *best_k, current_dimension_idx,
+			       n_vectors_not_pruned, dim_clip_value.get());
 			Prune(prepared_query, cluster.data, cluster.num_embeddings, k, pruning_positions.get(),
 			      pruning_distances.get(), pruning_threshold, *best_k, current_dimension_idx, n_vectors_not_pruned,
 			      dim_clip_value.get());
@@ -381,8 +381,8 @@ public:
 		std::unique_ptr<DISTANCES_TYPE[]> pruning_distances(new DISTANCES_TYPE[max_cluster_size]);
 		std::unique_ptr<uint32_t[]> pruning_positions(new uint32_t[max_cluster_size]);
 
-		const size_t end_idx = std::min<size_t>(cluster_indices_in_access_order_offset + num_clusters_to_probe,
-		                                        pdx_data.num_clusters);
+		const size_t end_idx =
+		    std::min<size_t>(cluster_indices_in_access_order_offset + num_clusters_to_probe, pdx_data.num_clusters);
 		for (; cluster_indices_in_access_order_offset < end_idx; ++cluster_indices_in_access_order_offset) {
 			DISTANCES_TYPE pruning_threshold = std::numeric_limits<DISTANCES_TYPE>::max();
 			uint32_t current_dimension_idx = 0;
@@ -443,10 +443,10 @@ public:
 		                                 n_vectors); // Note: Start() should not be called if heap.size() >= k
 		std::unique_ptr<size_t[]> indices_sorted(new size_t[n_vectors]);
 		std::iota(indices_sorted.get(), indices_sorted.get() + n_vectors, static_cast<size_t>(0));
-		std::partial_sort(
-		    indices_sorted.get(), indices_sorted.get() + static_cast<int64_t>(max_possible_k),
-		    indices_sorted.get() + n_vectors,
-		    [pruning_distances](size_t i1, size_t i2) { return pruning_distances[i1] < pruning_distances[i2]; });
+		std::partial_sort(indices_sorted.get(), indices_sorted.get() + static_cast<int64_t>(max_possible_k),
+		                  indices_sorted.get() + n_vectors, [pruning_distances](size_t i1, size_t i2) {
+			                  return pruning_distances[i1] < pruning_distances[i2];
+		                  });
 		// insert first k results into the heap
 		for (size_t idx = 0; idx < max_possible_k; ++idx) {
 			auto embedding = KNNCandidate<Q> {};
@@ -495,10 +495,10 @@ public:
 		MaskDistancesWithSelectionVector(n_vectors, pruning_distances, selection_vector);
 		std::unique_ptr<size_t[]> indices_sorted(new size_t[n_vectors]);
 		std::iota(indices_sorted.get(), indices_sorted.get() + n_vectors, static_cast<size_t>(0));
-		std::partial_sort(
-		    indices_sorted.get(), indices_sorted.get() + static_cast<int64_t>(max_possible_k),
-		    indices_sorted.get() + n_vectors,
-		    [pruning_distances](size_t i1, size_t i2) { return pruning_distances[i1] < pruning_distances[i2]; });
+		std::partial_sort(indices_sorted.get(), indices_sorted.get() + static_cast<int64_t>(max_possible_k),
+		                  indices_sorted.get() + n_vectors, [pruning_distances](size_t i1, size_t i2) {
+			                  return pruning_distances[i1] < pruning_distances[i2];
+		                  });
 		// insert first k results into the heap
 		for (size_t idx = 0; idx < max_possible_k; ++idx) {
 			auto embedding = KNNCandidate<Q> {};
@@ -529,7 +529,8 @@ public:
 		GetClustersAccessOrderIVF(query.get(), pdx_data, clusters_to_visit, local_cluster_order.get());
 		// PDXearch core
 		std::unique_ptr<int32_t[]> local_dim_clip_value(new int32_t[pdx_data.num_dimensions]());
-		std::unique_ptr<QUANTIZED_VECTOR_TYPE[]> local_quantized_query(new QUANTIZED_VECTOR_TYPE[pdx_data.num_dimensions]);
+		std::unique_ptr<QUANTIZED_VECTOR_TYPE[]> local_quantized_query(
+		    new QUANTIZED_VECTOR_TYPE[pdx_data.num_dimensions]);
 		QUANTIZED_VECTOR_TYPE *local_prepared_query;
 		if constexpr (q == U8) {
 			quantizer.PrepareQuery(query.get(), pdx_data.for_base, pdx_data.scale_factor, local_dim_clip_value.get(),
@@ -593,7 +594,8 @@ public:
 		GetClustersAccessOrderIVF(query.get(), pdx_data, clusters_to_visit, local_cluster_order.get());
 		// PDXearch core
 		std::unique_ptr<int32_t[]> local_dim_clip_value(new int32_t[pdx_data.num_dimensions]());
-		std::unique_ptr<QUANTIZED_VECTOR_TYPE[]> local_quantized_query(new QUANTIZED_VECTOR_TYPE[pdx_data.num_dimensions]);
+		std::unique_ptr<QUANTIZED_VECTOR_TYPE[]> local_quantized_query(
+		    new QUANTIZED_VECTOR_TYPE[pdx_data.num_dimensions]);
 		QUANTIZED_VECTOR_TYPE *local_prepared_query;
 		if constexpr (q == U8) {
 			quantizer.PrepareQuery(query.get(), pdx_data.for_base, pdx_data.scale_factor, local_dim_clip_value.get(),
@@ -624,8 +626,8 @@ public:
 			if (local_heap.size() < k) {
 				// We cannot prune until we fill the heap
 				FilteredStart(local_prepared_query, cluster.data, cluster.num_embeddings, k, cluster.indices,
-				              pruning_positions.get(), pruning_distances.get(), local_heap,
-				              local_dim_clip_value.get(), selection_vector, passing_tuples);
+				              pruning_positions.get(), pruning_distances.get(), local_heap, local_dim_clip_value.get(),
+				              selection_vector, passing_tuples);
 				continue;
 			}
 			Warmup<q, true>(local_prepared_query, cluster.data, cluster.num_embeddings, k, selectivity_threshold,

--- a/src/include/pdxearch/pruners/adsampling.hpp
+++ b/src/include/pdxearch/pruners/adsampling.hpp
@@ -36,8 +36,7 @@ class ADSamplingPruner {
 public:
 	const uint32_t num_dimensions;
 
-	ADSamplingPruner(const uint32_t num_dimensions, const float *matrix_p)
-	    : num_dimensions(num_dimensions){
+	ADSamplingPruner(const uint32_t num_dimensions, const float *matrix_p) : num_dimensions(num_dimensions) {
 		ratios.resize(num_dimensions);
 		for (size_t i = 0; i < num_dimensions; ++i) {
 			ratios[i] = GetRatio(i);
@@ -100,7 +99,8 @@ private:
 			return 1.0;
 		}
 		return static_cast<float>(visited_dimensions) / num_dimensions *
-		       (1.0 + pruning_aggressiveness / std::sqrt(visited_dimensions)) * (1.0 + pruning_aggressiveness / std::sqrt(visited_dimensions));
+		       (1.0 + pruning_aggressiveness / std::sqrt(visited_dimensions)) *
+		       (1.0 + pruning_aggressiveness / std::sqrt(visited_dimensions));
 	}
 
 	/**

--- a/src/include/pdxearch/pruners/adsampling.hpp
+++ b/src/include/pdxearch/pruners/adsampling.hpp
@@ -36,8 +36,8 @@ class ADSamplingPruner {
 public:
 	const uint32_t num_dimensions;
 
-	ADSamplingPruner(const uint32_t num_dimensions, const float epsilon0, const float *matrix_p)
-	    : num_dimensions(num_dimensions), epsilon0(epsilon0) {
+	ADSamplingPruner(const uint32_t num_dimensions, const float *matrix_p)
+	    : num_dimensions(num_dimensions){
 		ratios.resize(num_dimensions);
 		for (size_t i = 0; i < num_dimensions; ++i) {
 			ratios[i] = GetRatio(i);
@@ -56,8 +56,8 @@ public:
 #endif
 	}
 
-	void SetEpsilon0(const float epsilon0) {
-		ADSamplingPruner::epsilon0 = epsilon0;
+	void SetPruningAggresiveness(const float pruning_aggressiveness) {
+		ADSamplingPruner::pruning_aggressiveness = pruning_aggressiveness;
 		for (size_t i = 0; i < num_dimensions; ++i) {
 			ratios[i] = GetRatio(i);
 		}
@@ -88,7 +88,7 @@ public:
 	}
 
 private:
-	float epsilon0 = 1.5;
+	float pruning_aggressiveness = ADSAMPLING_PRUNING_AGGRESIVENESS;
 	Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> matrix;
 	std::vector<float> ratios;
 
@@ -100,7 +100,7 @@ private:
 			return 1.0;
 		}
 		return static_cast<float>(visited_dimensions) / num_dimensions *
-		       (1.0 + epsilon0 / std::sqrt(visited_dimensions)) * (1.0 + epsilon0 / std::sqrt(visited_dimensions));
+		       (1.0 + pruning_aggressiveness / std::sqrt(visited_dimensions)) * (1.0 + pruning_aggressiveness / std::sqrt(visited_dimensions));
 	}
 
 	/**
@@ -117,7 +117,7 @@ private:
 	 * @param n Number of embeddings to rotate
 	 */
 	void Rotate(const VALUE_TYPE *SKM_RESTRICT const embeddings, VALUE_TYPE *SKM_RESTRICT const out_buffer,
-	            const uint32_t n) const {
+	            const size_t n) const {
 		Eigen::Map<const MatrixR> embeddings_matrix(embeddings, n, num_dimensions);
 		Eigen::Map<MatrixR> out(out_buffer, n, num_dimensions);
 		out.noalias() = embeddings_matrix * matrix.transpose();

--- a/src/index/create/pdxearch_index_create.cpp
+++ b/src/index/create/pdxearch_index_create.cpp
@@ -33,7 +33,7 @@ public:
 	                                            op.estimated_cardinality)),
 	      num_dimensions(ArrayType::GetSize(op.unbound_expressions[0]->return_type)),
 	      embedding_preprocessor(make_uniq<EmbeddingPreprocessor>(
-	          num_dimensions, global_index->Cast<PDXearchIndex>().GetRotationMatrix(), PDXearchWrapper::EPSILON0)),
+	          num_dimensions, global_index->Cast<PDXearchIndex>().GetRotationMatrix())),
 	      is_normalized(global_index->Cast<PDXearchIndex>().IsNormalized()) {
 	}
 

--- a/src/index/create/pdxearch_index_global_create.cpp
+++ b/src/index/create/pdxearch_index_global_create.cpp
@@ -40,7 +40,7 @@ public:
 	      embeddings(make_uniq_array<float>(max_num_embeddings * num_dimensions)),
 	      row_ids(make_uniq_array<row_t>(max_num_embeddings)),
 	      embedding_preprocessor(make_uniq<EmbeddingPreprocessor>(
-	          num_dimensions, global_index->Cast<PDXearchIndex>().GetRotationMatrix(), PDXearchWrapper::EPSILON0)),
+	          num_dimensions, global_index->Cast<PDXearchIndex>().GetRotationMatrix())),
 	      is_normalized(global_index->Cast<PDXearchIndex>().IsNormalized()) {
 	}
 	unique_ptr<BoundIndex> global_index;

--- a/src/index/search/pdxearch_index_filtered_scan_physical.cpp
+++ b/src/index/search/pdxearch_index_filtered_scan_physical.cpp
@@ -259,7 +259,6 @@ SinkFinalizeType PhysicalPDXearchIndexFilteredScan::Finalize(Pipeline &pipeline,
 // iteration, which will probe the next X clusters for each row group.
 void PhysicalFilteredScanGlobalSinkState::TryFinalizeSinkPhase(Pipeline &pipeline, Event &event) {
 	D_ASSERT(global_heap->size() <= limit);
-	D_ASSERT(partitions_per_row_group_probed_thus_far <= index.GetNumClustersPerRowGroup());
 
 	// The heap (and thus pruning threshold) is initialized with a max float element. This float element should not be
 	// part of the result (it is not valid). There is an edge case where this element is the Kth item (at the top of the

--- a/src/index/search/pdxearch_index_filtered_scan_physical.cpp
+++ b/src/index/search/pdxearch_index_filtered_scan_physical.cpp
@@ -31,8 +31,7 @@ public:
 	      preprocessed_query_embedding(make_uniq_array<float>(index.GetNumDimensions())), pdxearch_row_ids(nullptr) {
 
 		// Preprocess the query embedding.
-		EmbeddingPreprocessor embedding_preprocessor(index.GetNumDimensions(), index.GetRotationMatrix(),
-		                                             PDXearchWrapper::EPSILON0);
+		EmbeddingPreprocessor embedding_preprocessor(index.GetNumDimensions(), index.GetRotationMatrix());
 		embedding_preprocessor.PreprocessEmbedding(bind_data.query_embedding.get(), preprocessed_query_embedding.get(),
 		                                           index.IsNormalized());
 

--- a/src/index/search/pdxearch_index_scan_physical.cpp
+++ b/src/index/search/pdxearch_index_scan_physical.cpp
@@ -29,7 +29,7 @@ public:
 
 		// Preprocess the query embedding.
 		const EmbeddingPreprocessor embedding_preprocessor =
-		    EmbeddingPreprocessor(index.GetNumDimensions(), index.GetRotationMatrix(), PDXearchWrapper::EPSILON0);
+		    EmbeddingPreprocessor(index.GetNumDimensions(), index.GetRotationMatrix());
 		embedding_preprocessor.PreprocessEmbedding(bind_data.query_embedding.get(), preprocessed_query_embedding.get(),
 		                                           index.IsNormalized());
 


### PR DESCRIPTION
# Improvements
- Moving away from `std::vector` to `std::unique_ptr`
- Better management of Epsilon0: Parameter is now hidden from front-end and fixed to 1.5. It is possible to change it in runtime.
- Deciding on a fixed `number_of_clusters` per rowgroup

# Needs light discussion
- I have decided to fix the number of cluster per rowgroup to a fixed number: `480`. I explain **why** in the code.
- There is one missing aspect of this. What do we do if the number of embeddings in a rowgroup is less than 480? (see code `TODO`). I believe this was also an issue before, dus it not blocking.
  - Edit: I added internal issue #38 for this.