### PR TITLE
feature: Scalar Quantization (U8)

### DIFF
--- a/src/include/index/pdxearch_index.hpp
+++ b/src/include/index/pdxearch_index.hpp
@@ -39,13 +39,13 @@ public:
 	void SetUpIndexForRowGroup(const row_t *row_ids, const float *embeddings, idx_t num_embeddings, idx_t row_group_id);
 
 	void InitializeSearchForRowGroup(float *preprocessed_query_embedding, idx_t limit, idx_t row_group_id,
-	                                 PDX::Heap<PDX::F32> &heap, std::mutex &heap_mutex);
+	                                 PDX::Heap &heap, std::mutex &heap_mutex);
 
 	void SearchRowGroup(idx_t row_group_id, idx_t num_clusters_to_probe);
 
 	void InitializeFilteredSearchForRowGroup(float *preprocessed_query_embedding, idx_t limit,
 	                                         const std::vector<row_t> &passing_row_ids, idx_t row_group_id,
-	                                         PDX::Heap<PDX::F32> &heap, std::mutex &heap_mutex);
+	                                         PDX::Heap &heap, std::mutex &heap_mutex);
 
 	void FilteredSearchRowGroup(idx_t row_group_id, idx_t num_clusters_to_probe);
 

--- a/src/include/index/pdxearch_index.hpp
+++ b/src/include/index/pdxearch_index.hpp
@@ -116,15 +116,28 @@ public:
 	 ******************************************************************/
 
 	idx_t GetNumClustersPerRowGroup() const {
+		if (pdxearch_wrapper->GetQuantization() == PDX::U8) {
+			return static_cast<PDXearchWrapperU8 *>(pdxearch_wrapper.get())->GetNumClustersPerRowGroup();
+		}
 		return static_cast<PDXearchWrapperF32 *>(pdxearch_wrapper.get())->GetNumClustersPerRowGroup();
 	}
 
 	idx_t GetNumRowGroups() const {
+		if (pdxearch_wrapper->GetQuantization() == PDX::U8) {
+			return static_cast<PDXearchWrapperU8 *>(pdxearch_wrapper.get())->GetNumRowGroups();
+		}
 		return static_cast<PDXearchWrapperF32 *>(pdxearch_wrapper.get())->GetNumRowGroups();
 	}
 
 	idx_t GetNumClusters() const {
+		if (pdxearch_wrapper->GetQuantization() == PDX::U8) {
+			return static_cast<PDXearchWrapperGlobalU8 *>(pdxearch_wrapper.get())->GetNumClusters();
+		}
 		return static_cast<PDXearchWrapperGlobalF32 *>(pdxearch_wrapper.get())->GetNumClusters();
+	}
+
+	PDX::Quantization GetQuantization() const {
+		return pdxearch_wrapper->GetQuantization();
 	}
 
 	idx_t GetNumDimensions() const {

--- a/src/include/index/pdxearch_index_utils.hpp
+++ b/src/include/index/pdxearch_index_utils.hpp
@@ -98,10 +98,10 @@ StoreClusterEmbeddings<PDX::Quantization::F32, float>(PDX::IndexPDXIVF<PDX::Quan
 }
 
 template <>
-inline void StoreClusterEmbeddings<PDX::Quantization::U8, uint8_t>(
-    PDX::IndexPDXIVF<PDX::Quantization::U8>::CLUSTER_TYPE &cluster,
-    const PDX::IndexPDXIVF<PDX::Quantization::U8> &index, const uint8_t *const embeddings,
-    const size_t num_embeddings) {
+inline void
+StoreClusterEmbeddings<PDX::Quantization::U8, uint8_t>(PDX::IndexPDXIVF<PDX::Quantization::U8>::CLUSTER_TYPE &cluster,
+                                                       const PDX::IndexPDXIVF<PDX::Quantization::U8> &index,
+                                                       const uint8_t *const embeddings, const size_t num_embeddings) {
 	// Store the cluster's data using the transposed PDX layout for U8.
 	// The vertical block uses 4-way interleaving: for each group of 4 consecutive dimensions,
 	// each vector's 4 values are stored contiguously. This enables NEON vdotq_u32 processing.
@@ -120,8 +120,7 @@ inline void StoreClusterEmbeddings<PDX::Quantization::U8, uint8_t>(
 	size_t current_horizontal_offset = index.num_vertical_dimensions * num_embeddings;
 
 	for (size_t dim_group = 0; dim_group < index.num_horizontal_dimensions; dim_group += PDX::H_DIM_SIZE) {
-		size_t group_size =
-		    std::min(PDX::H_DIM_SIZE, static_cast<size_t>(index.num_horizontal_dimensions) - dim_group);
+		size_t group_size = std::min(PDX::H_DIM_SIZE, static_cast<size_t>(index.num_horizontal_dimensions) - dim_group);
 		size_t actual_dim = index.num_vertical_dimensions + dim_group;
 
 		for (size_t embedding = 0; embedding < num_embeddings; embedding++) {

--- a/src/include/index/pdxearch_index_utils.hpp
+++ b/src/include/index/pdxearch_index_utils.hpp
@@ -83,11 +83,10 @@ StoreClusterEmbeddings<PDX::Quantization::F32, float>(PDX::IndexPDXIVF<PDX::Quan
 	}
 
 	// Horizontal dimensions decomposed every 64 dimensions.
-	constexpr size_t HORIZONTAL_SUBVECTOR_LENGTH = 64;
 	size_t current_horizontal_offset = index.num_vertical_dimensions * num_embeddings;
 
-	for (size_t dim_group = 0; dim_group < index.num_horizontal_dimensions; dim_group += HORIZONTAL_SUBVECTOR_LENGTH) {
-		size_t group_size = std::min(HORIZONTAL_SUBVECTOR_LENGTH, index.num_horizontal_dimensions - dim_group);
+	for (size_t dim_group = 0; dim_group < index.num_horizontal_dimensions; dim_group += PDX::H_DIM_SIZE) {
+		size_t group_size = std::min(PDX::H_DIM_SIZE, index.num_horizontal_dimensions - dim_group);
 		size_t actual_dim = index.num_vertical_dimensions + dim_group;
 
 		for (size_t embedding = 0; embedding < num_embeddings; embedding++) {
@@ -118,12 +117,11 @@ inline void StoreClusterEmbeddings<PDX::Quantization::U8, uint8_t>(
 	}
 
 	// Horizontal dimensions decomposed every 64 dimensions (same layout as F32, with uint8_t).
-	constexpr size_t HORIZONTAL_SUBVECTOR_LENGTH = 64;
 	size_t current_horizontal_offset = index.num_vertical_dimensions * num_embeddings;
 
-	for (size_t dim_group = 0; dim_group < index.num_horizontal_dimensions; dim_group += HORIZONTAL_SUBVECTOR_LENGTH) {
+	for (size_t dim_group = 0; dim_group < index.num_horizontal_dimensions; dim_group += PDX::H_DIM_SIZE) {
 		size_t group_size =
-		    std::min(HORIZONTAL_SUBVECTOR_LENGTH, static_cast<size_t>(index.num_horizontal_dimensions) - dim_group);
+		    std::min(PDX::H_DIM_SIZE, static_cast<size_t>(index.num_horizontal_dimensions) - dim_group);
 		size_t actual_dim = index.num_vertical_dimensions + dim_group;
 
 		for (size_t embedding = 0; embedding < num_embeddings; embedding++) {

--- a/src/include/index/pdxearch_wrapper.hpp
+++ b/src/include/index/pdxearch_wrapper.hpp
@@ -205,9 +205,9 @@ public:
 
 				if constexpr (Q == PDX::U8) {
 					PDX::ScalarQuantizer<Q> quantizer(num_dimensions);
-					quantizer.QuantizeVector(embeddings + (embedding_idx * num_dimensions), quantization_base,
-					                         quantization_scale,
-					                         tmp_cluster_embeddings.get() + (position_in_cluster * num_dimensions));
+					quantizer.QuantizeEmbedding(embeddings + (embedding_idx * num_dimensions), quantization_base,
+					                            quantization_scale,
+					                            tmp_cluster_embeddings.get() + (position_in_cluster * num_dimensions));
 				} else {
 					memcpy(tmp_cluster_embeddings.get() + (position_in_cluster * num_dimensions),
 					       embeddings + (embedding_idx * num_dimensions), num_dimensions * sizeof(float));
@@ -355,9 +355,9 @@ public:
 
 				if constexpr (Q == PDX::U8) {
 					PDX::ScalarQuantizer<Q> quantizer(num_dimensions);
-					quantizer.QuantizeVector(embeddings + (embedding_idx * num_dimensions), quantization_base,
-					                         quantization_scale,
-					                         tmp_cluster_embeddings.get() + (position_in_cluster * num_dimensions));
+					quantizer.QuantizeEmbedding(embeddings + (embedding_idx * num_dimensions), quantization_base,
+					                            quantization_scale,
+					                            tmp_cluster_embeddings.get() + (position_in_cluster * num_dimensions));
 				} else {
 					memcpy(tmp_cluster_embeddings.get() + (position_in_cluster * num_dimensions),
 					       embeddings + (embedding_idx * num_dimensions), num_dimensions * sizeof(float));

--- a/src/include/index/pdxearch_wrapper.hpp
+++ b/src/include/index/pdxearch_wrapper.hpp
@@ -164,12 +164,11 @@ public:
 			    embeddings, static_cast<size_t>(num_embeddings) * num_dimensions);
 			quantization_base = params.quantization_base;
 			quantization_scale = params.quantization_scale;
-			row_group.index = make_uniq<PDX::IndexPDXIVF<Q>>(num_dimensions, num_embeddings,
-			                                                  num_clusters_per_row_group, IsNormalized(),
-			                                                  quantization_scale, quantization_base);
+			row_group.index = make_uniq<PDX::IndexPDXIVF<Q>>(num_dimensions, num_embeddings, num_clusters_per_row_group,
+			                                                 IsNormalized(), quantization_scale, quantization_base);
 		} else {
-			row_group.index = make_uniq<PDX::IndexPDXIVF<Q>>(num_dimensions, num_embeddings,
-			                                                  num_clusters_per_row_group, IsNormalized());
+			row_group.index = make_uniq<PDX::IndexPDXIVF<Q>>(num_dimensions, num_embeddings, num_clusters_per_row_group,
+			                                                 IsNormalized());
 		}
 		row_group.pruner = make_uniq<PDX::ADSamplingPruner<Q>>(num_dimensions, rotation_matrix.get());
 
@@ -291,8 +290,8 @@ private:
 	std::unique_ptr<PDX::PDXearch<Q>> searcher;
 
 public:
-	PDXearchWrapperGlobal(PDX::DistanceMetric distance_metric, uint32_t num_dimensions, uint32_t n_probe,
-	                      int32_t seed, idx_t estimated_cardinality)
+	PDXearchWrapperGlobal(PDX::DistanceMetric distance_metric, uint32_t num_dimensions, uint32_t n_probe, int32_t seed,
+	                      idx_t estimated_cardinality)
 	    : PDXearchWrapper(Q, distance_metric, num_dimensions, n_probe, seed),
 	      num_clusters(ComputeNumberOfClusters(estimated_cardinality)), total_num_embeddings(estimated_cardinality),
 	      row_id_cluster_mapping(estimated_cardinality),
@@ -317,14 +316,14 @@ public:
 			quantization_base = params.quantization_base;
 			quantization_scale = params.quantization_scale;
 			index = make_uniq<PDX::IndexPDXIVF<Q>>(num_dimensions, num_embeddings, num_clusters, IsNormalized(),
-			                                        quantization_scale, quantization_base);
+			                                       quantization_scale, quantization_base);
 		} else {
 			index = make_uniq<PDX::IndexPDXIVF<Q>>(num_dimensions, num_embeddings, num_clusters, IsNormalized());
 		}
 
 		// Compute K-means centroids and embedding-to-centroid assignment (always on float embeddings).
-		KMeansResult kmeans_result = ComputeKMeans(embeddings, num_embeddings, num_dimensions, num_clusters,
-		                                           GetDistanceMetric(), GetSeed());
+		KMeansResult kmeans_result =
+		    ComputeKMeans(embeddings, num_embeddings, num_dimensions, num_clusters, GetDistanceMetric(), GetSeed());
 
 		// Store centroids.
 		index->centroids = std::move(kmeans_result.centroids);
@@ -365,7 +364,8 @@ public:
 				}
 			}
 
-			StoreClusterEmbeddings<Q, EmbeddingStorageType>(cluster, *index, tmp_cluster_embeddings.get(), cluster_size);
+			StoreClusterEmbeddings<Q, EmbeddingStorageType>(cluster, *index, tmp_cluster_embeddings.get(),
+			                                                cluster_size);
 		}
 
 		// Note: the searcher depends on a fully initialized index in its constructor.

--- a/src/include/pdxearch/common.hpp
+++ b/src/include/pdxearch/common.hpp
@@ -18,10 +18,10 @@
 #endif
 
 #if defined(__GNUC__) || defined(__clang__)
-#define PDX_LIKELY(x) __builtin_expect(!!(x), 1)
+#define PDX_LIKELY(x)   __builtin_expect(!!(x), 1)
 #define PDX_UNLIKELY(x) __builtin_expect(!!(x), 0)
 #else
-#define PDX_LIKELY(x) (x)
+#define PDX_LIKELY(x)   (x)
 #define PDX_UNLIKELY(x) (x)
 #endif
 

--- a/src/include/pdxearch/common.hpp
+++ b/src/include/pdxearch/common.hpp
@@ -79,7 +79,7 @@ struct QuantizedVectorType<F32> {
 	using type = float;
 };
 template <Quantization q>
-using QuantizedVectorType_t = typename QuantizedVectorType<q>::type;
+using QuantizedEmbeddingType_t = typename QuantizedVectorType<q>::type;
 
 struct KNNCandidate {
 	uint32_t index;

--- a/src/include/pdxearch/common.hpp
+++ b/src/include/pdxearch/common.hpp
@@ -34,6 +34,16 @@ static constexpr size_t H_DIM_SIZE = 64;
 static constexpr uint32_t DIMENSIONS_FETCHING_SIZES[20] = {16,  16,  32,  32,  32,  32,  64,  64,   64,   64,
                                                            128, 128, 128, 128, 256, 256, 512, 1024, 2048, 65536};
 
+static constexpr bool AllFetchingSizesMultipleOf4() {
+	for (auto s : DIMENSIONS_FETCHING_SIZES) {
+		if (s % 4 != 0) {
+			return false;
+		}
+	}
+	return true;
+}
+static_assert(AllFetchingSizesMultipleOf4(), "All DIMENSIONS_FETCHING_SIZES must be multiples of 4");
+
 // Epsilon0 parameter of ADSampling (Reference: https://dl.acm.org/doi/abs/10.1145/3589282)
 static constexpr float ADSAMPLING_PRUNING_AGGRESIVENESS = 1.5f;
 

--- a/src/include/pdxearch/distance_computers/avx2_computers.hpp
+++ b/src/include/pdxearch/distance_computers/avx2_computers.hpp
@@ -14,7 +14,7 @@ template <>
 class SIMDComputer<DistanceMetric::L2SQ, Quantization::F32> {
 public:
 	using DISTANCE_TYPE = DistanceType_t<F32>;
-	using QUERY_TYPE = QuantizedVectorType_t<F32>;
+	using QUERY_TYPE = QuantizedEmbeddingType_t<F32>;
 	using DATA_TYPE = DataType_t<F32>;
 	using scalar_computer = ScalarComputer<DistanceMetric::L2SQ, Quantization::F32>;
 
@@ -84,7 +84,7 @@ template <>
 class SIMDComputer<DistanceMetric::L2SQ, Quantization::U8> {
 public:
 	using DISTANCE_TYPE = DistanceType_t<U8>;
-	using QUERY_TYPE = QuantizedVectorType_t<U8>;
+	using QUERY_TYPE = QuantizedEmbeddingType_t<U8>;
 	using DATA_TYPE = DataType_t<U8>;
 
 	template <bool SKIP_PRUNED>

--- a/src/include/pdxearch/distance_computers/avx2_computers.hpp
+++ b/src/include/pdxearch/distance_computers/avx2_computers.hpp
@@ -21,7 +21,7 @@ public:
 	template <bool SKIP_PRUNED>
 	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
 	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, DISTANCE_TYPE *distances_p,
-	                     const uint32_t *pruning_positions = nullptr, const int32_t *dim_clip_value = nullptr) {
+	                     const uint32_t *pruning_positions = nullptr) {
 		size_t dimensions_jump_factor = total_vectors;
 		for (size_t dimension_idx = start_dimension; dimension_idx < end_dimension; ++dimension_idx) {
 			size_t offset_to_dimension_start = dimension_idx * dimensions_jump_factor;
@@ -37,7 +37,7 @@ public:
 	}
 
 	static DISTANCE_TYPE Horizontal(const QUERY_TYPE *__restrict vector1, const DATA_TYPE *__restrict vector2,
-	                                size_t num_dimensions, const float *scaling_factors = nullptr) {
+	                                size_t num_dimensions) {
 		__m256 d2_vec = _mm256_setzero_ps();
 		size_t i = 0;
 		for (; i + 8 <= num_dimensions; i += 8) {

--- a/src/include/pdxearch/distance_computers/avx2_computers.hpp
+++ b/src/include/pdxearch/distance_computers/avx2_computers.hpp
@@ -80,4 +80,85 @@ public:
 	};
 };
 
+template <>
+class SIMDComputer<DistanceMetric::L2SQ, Quantization::U8> {
+public:
+	using DISTANCE_TYPE = DistanceType_t<U8>;
+	using QUERY_TYPE = QuantizedVectorType_t<U8>;
+	using DATA_TYPE = DataType_t<U8>;
+
+	template <bool SKIP_PRUNED>
+	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
+	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, DISTANCE_TYPE *distances_p,
+	                     const uint32_t *pruning_positions = nullptr) {
+		uint32_t *query_grouped = (uint32_t *)query;
+		for (size_t dim_idx = start_dimension; dim_idx < end_dimension; dim_idx += 4) {
+			uint32_t dimension_idx = dim_idx;
+			size_t offset_to_dimension_start = dimension_idx * total_vectors;
+			size_t i = 0;
+			if constexpr (!SKIP_PRUNED) {
+				uint32_t query_value = query_grouped[dimension_idx / 4];
+				__m256i vec1_u8 = _mm256_set1_epi32(query_value);
+				__m256i zeros = _mm256_setzero_si256();
+				for (; i + 8 <= n_vectors; i += 8) {
+					// Load 8 accumulated distances and 32 bytes of data (4 dims x 8 vectors).
+					__m256i res = _mm256_loadu_si256((__m256i const *)&distances_p[i]);
+					__m256i vec2_u8 = _mm256_loadu_si256((__m256i const *)&data[offset_to_dimension_start + i * 4]);
+					__m256i diff =
+					    _mm256_or_si256(_mm256_subs_epu8(vec1_u8, vec2_u8), _mm256_subs_epu8(vec2_u8, vec1_u8));
+					// Zero-extend bytes to 16-bit, square, and horizontal-add to 32-bit.
+					__m256i lo16 = _mm256_unpacklo_epi8(diff, zeros);
+					__m256i hi16 = _mm256_unpackhi_epi8(diff, zeros);
+					__m256i sq_lo = _mm256_madd_epi16(lo16, lo16);
+					__m256i sq_hi = _mm256_madd_epi16(hi16, hi16);
+					// hadd combines partial sums: [v0, v1, v2, v3, v4, v5, v6, v7].
+					__m256i sums = _mm256_hadd_epi32(sq_lo, sq_hi);
+					_mm256_storeu_si256((__m256i *)&distances_p[i], _mm256_add_epi32(res, sums));
+				}
+			}
+			// Scalar tail.
+			for (; i < n_vectors; ++i) {
+				size_t vector_idx = i;
+				if constexpr (SKIP_PRUNED) {
+					vector_idx = pruning_positions[vector_idx];
+				}
+				int da = query[dimension_idx] - data[offset_to_dimension_start + (vector_idx * 4)];
+				int db = query[dimension_idx + 1] - data[offset_to_dimension_start + (vector_idx * 4) + 1];
+				int dc = query[dimension_idx + 2] - data[offset_to_dimension_start + (vector_idx * 4) + 2];
+				int dd = query[dimension_idx + 3] - data[offset_to_dimension_start + (vector_idx * 4) + 3];
+				distances_p[vector_idx] += (da * da) + (db * db) + (dc * dc) + (dd * dd);
+			}
+		}
+	}
+
+	static DISTANCE_TYPE Horizontal(const QUERY_TYPE *__restrict vector1, const DATA_TYPE *__restrict vector2,
+	                                size_t num_dimensions) {
+		__m256i d2_vec = _mm256_setzero_si256();
+		__m256i zeros = _mm256_setzero_si256();
+		size_t i = 0;
+		for (; i + 32 <= num_dimensions; i += 32) {
+			__m256i a_vec = _mm256_loadu_si256((__m256i const *)(vector1 + i));
+			__m256i b_vec = _mm256_loadu_si256((__m256i const *)(vector2 + i));
+			__m256i diff = _mm256_or_si256(_mm256_subs_epu8(a_vec, b_vec), _mm256_subs_epu8(b_vec, a_vec));
+			__m256i lo16 = _mm256_unpacklo_epi8(diff, zeros);
+			__m256i hi16 = _mm256_unpackhi_epi8(diff, zeros);
+			d2_vec = _mm256_add_epi32(d2_vec, _mm256_madd_epi16(lo16, lo16));
+			d2_vec = _mm256_add_epi32(d2_vec, _mm256_madd_epi16(hi16, hi16));
+		}
+		// Reduce 8 x i32 to scalar (simsimd_reduce_i32x8_haswell)
+		__m128i lo = _mm256_castsi256_si128(d2_vec);
+		__m128i hi = _mm256_extracti128_si256(d2_vec, 1);
+		__m128i sum128 = _mm_add_epi32(lo, hi);
+		sum128 = _mm_hadd_epi32(sum128, sum128);
+		sum128 = _mm_hadd_epi32(sum128, sum128);
+		DISTANCE_TYPE distance = _mm_cvtsi128_si32(sum128);
+		// Scalar tail.
+		for (; i < num_dimensions; ++i) {
+			int n = static_cast<int>(vector1[i]) - static_cast<int>(vector2[i]);
+			distance += n * n;
+		}
+		return distance;
+	};
+};
+
 } // namespace PDX

--- a/src/include/pdxearch/distance_computers/avx512_computers.hpp
+++ b/src/include/pdxearch/distance_computers/avx512_computers.hpp
@@ -22,7 +22,7 @@ public:
 	template <bool SKIP_PRUNED>
 	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
 	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, DISTANCE_TYPE *distances_p,
-	                     const uint32_t *pruning_positions = nullptr, const int32_t *dim_clip_value = nullptr) {
+	                     const uint32_t *pruning_positions = nullptr) {
 		size_t dimensions_jump_factor = total_vectors;
 		for (size_t dimension_idx = start_dimension; dimension_idx < end_dimension; ++dimension_idx) {
 			size_t offset_to_dimension_start = dimension_idx * dimensions_jump_factor;
@@ -38,7 +38,7 @@ public:
 	}
 
 	static DISTANCE_TYPE Horizontal(const QUERY_TYPE *__restrict vector1, const DATA_TYPE *__restrict vector2,
-	                                size_t num_dimensions, const float *scaling_factors = nullptr) {
+	                                size_t num_dimensions) {
 		__m512 d2_vec = _mm512_setzero();
 		__m512 a_vec, b_vec;
 	simsimd_l2sq_f32_skylake_cycle:

--- a/src/include/pdxearch/distance_computers/avx512_computers.hpp
+++ b/src/include/pdxearch/distance_computers/avx512_computers.hpp
@@ -14,7 +14,7 @@ template <>
 class SIMDComputer<DistanceMetric::L2SQ, Quantization::F32> {
 public:
 	using DISTANCE_TYPE = DistanceType_t<F32>;
-	using QUERY_TYPE = QuantizedVectorType_t<F32>;
+	using QUERY_TYPE = QuantizedEmbeddingType_t<F32>;
 	using DATA_TYPE = DataType_t<F32>;
 
 	template <bool SKIP_PRUNED>
@@ -68,7 +68,7 @@ template <>
 class SIMDComputer<DistanceMetric::L2SQ, Quantization::U8> {
 public:
 	using DISTANCE_TYPE = DistanceType_t<U8>;
-	using QUERY_TYPE = QuantizedVectorType_t<U8>;
+	using QUERY_TYPE = QuantizedEmbeddingType_t<U8>;
 	using DATA_TYPE = DataType_t<U8>;
 
 	template <bool SKIP_PRUNED>

--- a/src/include/pdxearch/distance_computers/avx512_computers.hpp
+++ b/src/include/pdxearch/distance_computers/avx512_computers.hpp
@@ -4,7 +4,6 @@
 #include <cassert>
 #include <immintrin.h>
 #include "pdxearch/common.hpp"
-#include "pdxearch/distance_computers/scalar_computers.hpp"
 
 namespace PDX {
 
@@ -17,7 +16,6 @@ public:
 	using DISTANCE_TYPE = DistanceType_t<F32>;
 	using QUERY_TYPE = QuantizedVectorType_t<F32>;
 	using DATA_TYPE = DataType_t<F32>;
-	using scalar_computer = ScalarComputer<DistanceMetric::L2SQ, Quantization::F32>;
 
 	template <bool SKIP_PRUNED>
 	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
@@ -63,6 +61,102 @@ public:
 		__m128 r = _mm512_castps512_ps128(_mm512_add_ps(x, _mm512_shuffle_f32x4(x, x, _MM_SHUFFLE(0, 0, 0, 1))));
 		r = _mm_hadd_ps(r, r);
 		return _mm_cvtss_f32(_mm_hadd_ps(r, r));
+	};
+};
+
+template <>
+class SIMDComputer<DistanceMetric::L2SQ, Quantization::U8> {
+public:
+	using DISTANCE_TYPE = DistanceType_t<U8>;
+	using QUERY_TYPE = QuantizedVectorType_t<U8>;
+	using DATA_TYPE = DataType_t<U8>;
+
+	template <bool SKIP_PRUNED>
+	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
+	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, DISTANCE_TYPE *distances_p,
+	                     const uint32_t *pruning_positions = nullptr) {
+		__m512i res;
+		__m512i vec2_u8;
+		__m512i vec1_u8;
+		__m512i diff_u8;
+		__m256i y_res;
+		__m256i y_vec2_u8;
+		__m256i y_vec1_u8;
+		__m256i y_diff_u8;
+		uint32_t *query_grouped = (uint32_t *)query;
+		for (size_t dim_idx = start_dimension; dim_idx < end_dimension; dim_idx += 4) {
+			uint32_t dimension_idx = dim_idx;
+			size_t offset_to_dimension_start = dimension_idx * total_vectors;
+			size_t i = 0;
+			if constexpr (!SKIP_PRUNED) {
+				// To load the query efficiently I will load it as uint32_t (4 bytes packed in 1 word)
+				uint32_t query_value = query_grouped[dimension_idx / 4];
+				// And then broadcast it to the register
+				vec1_u8 = _mm512_set1_epi32(query_value);
+				for (; i + 16 <= n_vectors; i += 16) {
+					// Read 64 bytes of data (64 values) with 4 dimensions of 16 vectors
+					res = _mm512_load_si512(&distances_p[i]);
+					vec2_u8 = _mm512_loadu_si512(
+					    &data[offset_to_dimension_start + i * 4]); // This 4 is because everytime I read 4 dimensions
+					diff_u8 = _mm512_or_si512(_mm512_subs_epu8(vec1_u8, vec2_u8), _mm512_subs_epu8(vec2_u8, vec1_u8));
+					// We can use this asymmetric dot product as our values are mostly 7-bit
+					// Hence, the [sign] properties of the second operand are ignored
+					// As results will never be negative, it can be stored on distances_p[i] without issues
+					// and it saturates to MAX_INT
+					_mm512_store_epi32(&distances_p[i], _mm512_dpbusds_epi32(res, diff_u8, diff_u8));
+				}
+				y_vec1_u8 = _mm256_set1_epi32(query_value);
+				for (; i + 8 <= n_vectors; i += 8) {
+					// Read 32 bytes of data (32 values) with 4 dimensions of 8 vectors
+					y_res = _mm256_load_epi32(&distances_p[i]);
+					y_vec2_u8 = _mm256_loadu_epi8(
+					    &data[offset_to_dimension_start + i * 4]); // This 4 is because everytime I read 4 dimensions
+					y_diff_u8 =
+					    _mm256_or_si256(_mm256_subs_epu8(y_vec1_u8, y_vec2_u8), _mm256_subs_epu8(y_vec2_u8, y_vec1_u8));
+					_mm256_store_epi32(&distances_p[i], _mm256_dpbusds_epi32(y_res, y_diff_u8, y_diff_u8));
+				}
+			}
+			// rest
+			for (; i < n_vectors; ++i) {
+				size_t vector_idx = i;
+				if constexpr (SKIP_PRUNED) {
+					vector_idx = pruning_positions[vector_idx];
+				}
+				int to_multiply_a = query[dimension_idx] - data[offset_to_dimension_start + (vector_idx * 4)];
+				int to_multiply_b = query[dimension_idx + 1] - data[offset_to_dimension_start + (vector_idx * 4) + 1];
+				int to_multiply_c = query[dimension_idx + 2] - data[offset_to_dimension_start + (vector_idx * 4) + 2];
+				int to_multiply_d = query[dimension_idx + 3] - data[offset_to_dimension_start + (vector_idx * 4) + 3];
+				distances_p[vector_idx] += (to_multiply_a * to_multiply_a) + (to_multiply_b * to_multiply_b) +
+				                           (to_multiply_c * to_multiply_c) + (to_multiply_d * to_multiply_d);
+			}
+		}
+	}
+
+	static DISTANCE_TYPE Horizontal(const QUERY_TYPE *__restrict vector1, const DATA_TYPE *__restrict vector2,
+	                                size_t num_dimensions) {
+		__m512i d2_i32_vec = _mm512_setzero_si512();
+		__m512i a_u8_vec, b_u8_vec;
+
+	simsimd_l2sq_u8_ice_cycle:
+		if (num_dimensions < 64) {
+			const __mmask64 mask = (__mmask64)_bzhi_u64(0xFFFFFFFFFFFFFFFF, num_dimensions);
+			a_u8_vec = _mm512_maskz_loadu_epi8(mask, vector1);
+			b_u8_vec = _mm512_maskz_loadu_epi8(mask, vector2);
+			num_dimensions = 0;
+		} else {
+			a_u8_vec = _mm512_loadu_si512(vector1);
+			b_u8_vec = _mm512_loadu_si512(vector2);
+			vector1 += 64, vector2 += 64, num_dimensions -= 64;
+		}
+
+		// Substracting unsigned vectors in AVX-512 is done by saturating subtraction:
+		__m512i d_u8_vec = _mm512_or_si512(_mm512_subs_epu8(a_u8_vec, b_u8_vec), _mm512_subs_epu8(b_u8_vec, a_u8_vec));
+
+		// Multiply and accumulate at `int8` level which are actually uint7, accumulate at `int32` level:
+		d2_i32_vec = _mm512_dpbusds_epi32(d2_i32_vec, d_u8_vec, d_u8_vec);
+		if (num_dimensions)
+			goto simsimd_l2sq_u8_ice_cycle;
+		return _mm512_reduce_add_epi32(d2_i32_vec);
 	};
 };
 

--- a/src/include/pdxearch/distance_computers/base_computers.hpp
+++ b/src/include/pdxearch/distance_computers/base_computers.hpp
@@ -41,4 +41,19 @@ public:
 	constexpr static auto Horizontal = computer::Horizontal;
 };
 
+template <>
+class DistanceComputer<DistanceMetric::L2SQ, Quantization::U8> {
+#if !defined(__ARM_NEON) && !defined(__AVX2__) && !defined(__AVX512F__)
+	using computer = ScalarComputer<DistanceMetric::L2SQ, U8>;
+#else
+	using computer = SIMDComputer<DistanceMetric::L2SQ, U8>;
+#endif
+
+public:
+	constexpr static auto VerticalPruning = computer::Vertical<true>;
+	constexpr static auto Vertical = computer::Vertical<false>;
+
+	constexpr static auto Horizontal = computer::Horizontal;
+};
+
 } // namespace PDX

--- a/src/include/pdxearch/distance_computers/neon_computers.hpp
+++ b/src/include/pdxearch/distance_computers/neon_computers.hpp
@@ -19,7 +19,7 @@ public:
 	template <bool SKIP_PRUNED>
 	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
 	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, DISTANCE_TYPE *distances_p,
-	                     const uint32_t *pruning_positions) {
+	                     const uint32_t *pruning_positions = nullptr) {
 		size_t dimensions_jump_factor = total_vectors;
 		for (size_t dimension_idx = start_dimension; dimension_idx < end_dimension; ++dimension_idx) {
 			size_t offset_to_dimension_start = dimension_idx * dimensions_jump_factor;

--- a/src/include/pdxearch/distance_computers/neon_computers.hpp
+++ b/src/include/pdxearch/distance_computers/neon_computers.hpp
@@ -63,82 +63,69 @@ public:
 	};
 };
 
-
 template <>
-class SIMDComputer<DistanceMetric::L2SQ, Quantization::U8>{
+class SIMDComputer<DistanceMetric::L2SQ, Quantization::U8> {
 public:
-    using DISTANCE_TYPE = DistanceType_t<U8>;
-    using QUERY_TYPE = QuantizedVectorType_t<U8>;
-    using DATA_TYPE = DataType_t<U8>;
+	using DISTANCE_TYPE = DistanceType_t<U8>;
+	using QUERY_TYPE = QuantizedVectorType_t<U8>;
+	using DATA_TYPE = DataType_t<U8>;
 
-    template<bool SKIP_PRUNED>
-    static void Vertical(
-            const QUERY_TYPE *__restrict query,
-            const DATA_TYPE *__restrict data,
-            size_t n_vectors,
-            size_t total_vectors,
-            size_t start_dimension,
-            size_t end_dimension,
-            DISTANCE_TYPE * distances_p,
-            const uint32_t * pruning_positions = nullptr
-    ){
-        // TODO: Handle tail in dimension length, for now im not going to worry on that as all the datasets are divisible by 4
-        for (size_t dim_idx = start_dimension; dim_idx < end_dimension; dim_idx+=4) {
-            uint32_t dimension_idx = dim_idx;
-            uint8x8_t vals = vld1_u8(&query[dimension_idx]);
-            size_t offset_to_dimension_start = dimension_idx * total_vectors;
-            size_t i = 0;
-            if constexpr (!SKIP_PRUNED){
-                const uint8x16_t idx = {0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3};
-                const uint8x16_t vec1_u8 = vqtbl1q_u8(vcombine_u8(vals, vals), idx);
-                for (; i + 4 <= n_vectors; i+=4) {
-                    // Read 16 bytes of data (16 values) with 4 dimensions of 4 vectors
-                    uint32x4_t res = vld1q_u32(&distances_p[i]);
-                    uint8x16_t vec2_u8 = vld1q_u8(&data[offset_to_dimension_start + i * 4]); // This 4 is because everytime I read 4 dimensions
-                    uint8x16_t diff_u8 = vabdq_u8(vec1_u8, vec2_u8);
-                    vst1q_u32(&distances_p[i], vdotq_u32(res, diff_u8, diff_u8));
-                }
-            }
-            for (; i < n_vectors; ++i) {
-                size_t vector_idx = i;
-                if constexpr (SKIP_PRUNED){
-                    vector_idx = pruning_positions[vector_idx];
-                }
-                // L2
-                int to_multiply_a = query[dimension_idx] - data[offset_to_dimension_start + (vector_idx * 4)];
-                int to_multiply_b = query[dimension_idx + 1] - data[offset_to_dimension_start + (vector_idx * 4) + 1];
-                int to_multiply_c = query[dimension_idx + 2] - data[offset_to_dimension_start + (vector_idx * 4) + 2];
-                int to_multiply_d = query[dimension_idx + 3] - data[offset_to_dimension_start + (vector_idx * 4) + 3];
-                distances_p[vector_idx] += (to_multiply_a * to_multiply_a) +
-                                           (to_multiply_b * to_multiply_b) +
-                                           (to_multiply_c * to_multiply_c) +
-                                           (to_multiply_d * to_multiply_d);
+	template <bool SKIP_PRUNED>
+	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
+	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, DISTANCE_TYPE *distances_p,
+	                     const uint32_t *pruning_positions = nullptr) {
+		// TODO: Handle tail in dimension length, for now im not going to worry on that as all the datasets are
+		// divisible by 4
+		for (size_t dim_idx = start_dimension; dim_idx < end_dimension; dim_idx += 4) {
+			uint32_t dimension_idx = dim_idx;
+			uint8x8_t vals = vld1_u8(&query[dimension_idx]);
+			size_t offset_to_dimension_start = dimension_idx * total_vectors;
+			size_t i = 0;
+			if constexpr (!SKIP_PRUNED) {
+				const uint8x16_t idx = {0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3};
+				const uint8x16_t vec1_u8 = vqtbl1q_u8(vcombine_u8(vals, vals), idx);
+				for (; i + 4 <= n_vectors; i += 4) {
+					// Read 16 bytes of data (16 values) with 4 dimensions of 4 vectors
+					uint32x4_t res = vld1q_u32(&distances_p[i]);
+					uint8x16_t vec2_u8 = vld1q_u8(
+					    &data[offset_to_dimension_start + i * 4]); // This 4 is because everytime I read 4 dimensions
+					uint8x16_t diff_u8 = vabdq_u8(vec1_u8, vec2_u8);
+					vst1q_u32(&distances_p[i], vdotq_u32(res, diff_u8, diff_u8));
+				}
+			}
+			for (; i < n_vectors; ++i) {
+				size_t vector_idx = i;
+				if constexpr (SKIP_PRUNED) {
+					vector_idx = pruning_positions[vector_idx];
+				}
+				// L2
+				int to_multiply_a = query[dimension_idx] - data[offset_to_dimension_start + (vector_idx * 4)];
+				int to_multiply_b = query[dimension_idx + 1] - data[offset_to_dimension_start + (vector_idx * 4) + 1];
+				int to_multiply_c = query[dimension_idx + 2] - data[offset_to_dimension_start + (vector_idx * 4) + 2];
+				int to_multiply_d = query[dimension_idx + 3] - data[offset_to_dimension_start + (vector_idx * 4) + 3];
+				distances_p[vector_idx] += (to_multiply_a * to_multiply_a) + (to_multiply_b * to_multiply_b) +
+				                           (to_multiply_c * to_multiply_c) + (to_multiply_d * to_multiply_d);
+			}
+		}
+	}
 
-            }
-        }
-    }
-
-    static DISTANCE_TYPE Horizontal(
-            const QUERY_TYPE *__restrict vector1,
-            const DATA_TYPE *__restrict vector2,
-            size_t num_dimensions
-    ){
-        uint32x4_t sum_vec = vdupq_n_u32(0);
-        size_t i = 0;
-        for (; i + 16 <= num_dimensions; i += 16) {
-            uint8x16_t a_vec = vld1q_u8(vector1 + i);
-            uint8x16_t b_vec = vld1q_u8(vector2 + i);
-            uint8x16_t d_vec = vabdq_u8(a_vec, b_vec);
-            sum_vec = vdotq_u32(sum_vec, d_vec, d_vec);
-        }
-        DISTANCE_TYPE distance = vaddvq_u32(sum_vec);
-        for (; i < num_dimensions; ++i) {
-            int n = (int)vector1[i] - vector2[i];
-            distance += n * n;
-        }
-        return distance;
-    };
+	static DISTANCE_TYPE Horizontal(const QUERY_TYPE *__restrict vector1, const DATA_TYPE *__restrict vector2,
+	                                size_t num_dimensions) {
+		uint32x4_t sum_vec = vdupq_n_u32(0);
+		size_t i = 0;
+		for (; i + 16 <= num_dimensions; i += 16) {
+			uint8x16_t a_vec = vld1q_u8(vector1 + i);
+			uint8x16_t b_vec = vld1q_u8(vector2 + i);
+			uint8x16_t d_vec = vabdq_u8(a_vec, b_vec);
+			sum_vec = vdotq_u32(sum_vec, d_vec, d_vec);
+		}
+		DISTANCE_TYPE distance = vaddvq_u32(sum_vec);
+		for (; i < num_dimensions; ++i) {
+			int n = (int)vector1[i] - vector2[i];
+			distance += n * n;
+		}
+		return distance;
+	};
 };
-
 
 } // namespace PDX

--- a/src/include/pdxearch/distance_computers/neon_computers.hpp
+++ b/src/include/pdxearch/distance_computers/neon_computers.hpp
@@ -13,7 +13,7 @@ template <>
 class SIMDComputer<DistanceMetric::L2SQ, Quantization::F32> {
 public:
 	using DISTANCE_TYPE = DistanceType_t<F32>;
-	using QUERY_TYPE = QuantizedVectorType_t<F32>;
+	using QUERY_TYPE = QuantizedEmbeddingType_t<F32>;
 	using DATA_TYPE = DataType_t<F32>;
 
 	template <bool SKIP_PRUNED>
@@ -80,7 +80,7 @@ template <>
 class SIMDComputer<DistanceMetric::L2SQ, Quantization::U8> {
 public:
 	using DISTANCE_TYPE = DistanceType_t<U8>;
-	using QUERY_TYPE = QuantizedVectorType_t<U8>;
+	using QUERY_TYPE = QuantizedEmbeddingType_t<U8>;
 	using DATA_TYPE = DataType_t<U8>;
 
 	template <bool SKIP_PRUNED>

--- a/src/include/pdxearch/distance_computers/neon_computers.hpp
+++ b/src/include/pdxearch/distance_computers/neon_computers.hpp
@@ -19,7 +19,7 @@ public:
 	template <bool SKIP_PRUNED>
 	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
 	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, DISTANCE_TYPE *distances_p,
-	                     const uint32_t *pruning_positions, const int32_t *dim_clip_value) {
+	                     const uint32_t *pruning_positions) {
 		size_t dimensions_jump_factor = total_vectors;
 		for (size_t dimension_idx = start_dimension; dimension_idx < end_dimension; ++dimension_idx) {
 			size_t offset_to_dimension_start = dimension_idx * dimensions_jump_factor;
@@ -35,7 +35,7 @@ public:
 	}
 
 	static DISTANCE_TYPE Horizontal(const QUERY_TYPE *__restrict vector1, const DATA_TYPE *__restrict vector2,
-	                                size_t num_dimensions, const float *scaling_factors = nullptr) {
+	                                size_t num_dimensions) {
 #if defined(__APPLE__)
 		DISTANCE_TYPE distance = 0.0;
 #pragma clang loop vectorize(enable)
@@ -62,5 +62,83 @@ public:
 #endif
 	};
 };
+
+
+template <>
+class SIMDComputer<DistanceMetric::L2SQ, Quantization::U8>{
+public:
+    using DISTANCE_TYPE = DistanceType_t<U8>;
+    using QUERY_TYPE = QuantizedVectorType_t<U8>;
+    using DATA_TYPE = DataType_t<U8>;
+
+    template<bool SKIP_PRUNED>
+    static void Vertical(
+            const QUERY_TYPE *__restrict query,
+            const DATA_TYPE *__restrict data,
+            size_t n_vectors,
+            size_t total_vectors,
+            size_t start_dimension,
+            size_t end_dimension,
+            DISTANCE_TYPE * distances_p,
+            const uint32_t * pruning_positions = nullptr
+    ){
+        // TODO: Handle tail in dimension length, for now im not going to worry on that as all the datasets are divisible by 4
+        for (size_t dim_idx = start_dimension; dim_idx < end_dimension; dim_idx+=4) {
+            uint32_t dimension_idx = dim_idx;
+            uint8x8_t vals = vld1_u8(&query[dimension_idx]);
+            size_t offset_to_dimension_start = dimension_idx * total_vectors;
+            size_t i = 0;
+            if constexpr (!SKIP_PRUNED){
+                const uint8x16_t idx = {0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3};
+                const uint8x16_t vec1_u8 = vqtbl1q_u8(vcombine_u8(vals, vals), idx);
+                for (; i + 4 <= n_vectors; i+=4) {
+                    // Read 16 bytes of data (16 values) with 4 dimensions of 4 vectors
+                    uint32x4_t res = vld1q_u32(&distances_p[i]);
+                    uint8x16_t vec2_u8 = vld1q_u8(&data[offset_to_dimension_start + i * 4]); // This 4 is because everytime I read 4 dimensions
+                    uint8x16_t diff_u8 = vabdq_u8(vec1_u8, vec2_u8);
+                    vst1q_u32(&distances_p[i], vdotq_u32(res, diff_u8, diff_u8));
+                }
+            }
+            for (; i < n_vectors; ++i) {
+                size_t vector_idx = i;
+                if constexpr (SKIP_PRUNED){
+                    vector_idx = pruning_positions[vector_idx];
+                }
+                // L2
+                int to_multiply_a = query[dimension_idx] - data[offset_to_dimension_start + (vector_idx * 4)];
+                int to_multiply_b = query[dimension_idx + 1] - data[offset_to_dimension_start + (vector_idx * 4) + 1];
+                int to_multiply_c = query[dimension_idx + 2] - data[offset_to_dimension_start + (vector_idx * 4) + 2];
+                int to_multiply_d = query[dimension_idx + 3] - data[offset_to_dimension_start + (vector_idx * 4) + 3];
+                distances_p[vector_idx] += (to_multiply_a * to_multiply_a) +
+                                           (to_multiply_b * to_multiply_b) +
+                                           (to_multiply_c * to_multiply_c) +
+                                           (to_multiply_d * to_multiply_d);
+
+            }
+        }
+    }
+
+    static DISTANCE_TYPE Horizontal(
+            const QUERY_TYPE *__restrict vector1,
+            const DATA_TYPE *__restrict vector2,
+            size_t num_dimensions
+    ){
+        uint32x4_t sum_vec = vdupq_n_u32(0);
+        size_t i = 0;
+        for (; i + 16 <= num_dimensions; i += 16) {
+            uint8x16_t a_vec = vld1q_u8(vector1 + i);
+            uint8x16_t b_vec = vld1q_u8(vector2 + i);
+            uint8x16_t d_vec = vabdq_u8(a_vec, b_vec);
+            sum_vec = vdotq_u32(sum_vec, d_vec, d_vec);
+        }
+        DISTANCE_TYPE distance = vaddvq_u32(sum_vec);
+        for (; i < num_dimensions; ++i) {
+            int n = (int)vector1[i] - vector2[i];
+            distance += n * n;
+        }
+        return distance;
+    };
+};
+
 
 } // namespace PDX

--- a/src/include/pdxearch/distance_computers/neon_computers.hpp
+++ b/src/include/pdxearch/distance_computers/neon_computers.hpp
@@ -87,9 +87,8 @@ public:
 	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
 	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, DISTANCE_TYPE *distances_p,
 	                     const uint32_t *pruning_positions = nullptr) {
-		// TODO: Handle tail in dimension length, for now im not going to worry on that as all the datasets are
-		// divisible by 4
-		for (size_t dim_idx = start_dimension; dim_idx < end_dimension; dim_idx += 4) {
+		size_t dim_idx = start_dimension;
+		for (; dim_idx + 4 <= end_dimension; dim_idx += 4) {
 			uint32_t dimension_idx = dim_idx;
 			uint8x8_t vals = vld1_u8(&query[dimension_idx]);
 			size_t offset_to_dimension_start = dimension_idx * total_vectors;
@@ -111,13 +110,26 @@ public:
 				if constexpr (SKIP_PRUNED) {
 					vector_idx = pruning_positions[vector_idx];
 				}
-				// L2
 				int to_multiply_a = query[dimension_idx] - data[offset_to_dimension_start + (vector_idx * 4)];
 				int to_multiply_b = query[dimension_idx + 1] - data[offset_to_dimension_start + (vector_idx * 4) + 1];
 				int to_multiply_c = query[dimension_idx + 2] - data[offset_to_dimension_start + (vector_idx * 4) + 2];
 				int to_multiply_d = query[dimension_idx + 3] - data[offset_to_dimension_start + (vector_idx * 4) + 3];
 				distances_p[vector_idx] += (to_multiply_a * to_multiply_a) + (to_multiply_b * to_multiply_b) +
 				                           (to_multiply_c * to_multiply_c) + (to_multiply_d * to_multiply_d);
+			}
+		}
+		if (dim_idx < end_dimension) {
+			auto remaining = static_cast<uint32_t>(end_dimension - dim_idx);
+			size_t offset = dim_idx * total_vectors;
+			for (size_t i = 0; i < n_vectors; ++i) {
+				size_t vector_idx = i;
+				if constexpr (SKIP_PRUNED) {
+					vector_idx = pruning_positions[vector_idx];
+				}
+				for (uint32_t k = 0; k < remaining; ++k) {
+					int diff = query[dim_idx + k] - data[offset + vector_idx * remaining + k];
+					distances_p[vector_idx] += diff * diff;
+				}
 			}
 		}
 	}
@@ -134,7 +146,7 @@ public:
 		}
 		DISTANCE_TYPE distance = vaddvq_u32(sum_vec);
 		for (; i < num_dimensions; ++i) {
-			int n = (int)vector1[i] - vector2[i];
+			int n = static_cast<int>(vector1[i]) - vector2[i];
 			distance += n * n;
 		}
 		return distance;

--- a/src/include/pdxearch/distance_computers/scalar_computers.hpp
+++ b/src/include/pdxearch/distance_computers/scalar_computers.hpp
@@ -12,7 +12,7 @@ template <>
 class ScalarComputer<DistanceMetric::L2SQ, Quantization::F32> {
 public:
 	using DISTANCE_TYPE = DistanceType_t<F32>;
-	using QUERY_TYPE = QuantizedVectorType_t<F32>;
+	using QUERY_TYPE = QuantizedEmbeddingType_t<F32>;
 	using DATA_TYPE = DataType_t<F32>;
 
 	template <bool SKIP_PRUNED>
@@ -49,7 +49,7 @@ template <>
 class ScalarComputer<DistanceMetric::L2SQ, Quantization::U8> {
 public:
 	using DISTANCE_TYPE = DistanceType_t<U8>;
-	using QUERY_TYPE = QuantizedVectorType_t<U8>;
+	using QUERY_TYPE = QuantizedEmbeddingType_t<U8>;
 	using DATA_TYPE = DataType_t<U8>;
 
 	template <bool SKIP_PRUNED>

--- a/src/include/pdxearch/distance_computers/scalar_computers.hpp
+++ b/src/include/pdxearch/distance_computers/scalar_computers.hpp
@@ -45,4 +45,43 @@ public:
 	};
 };
 
+template <>
+class ScalarComputer<DistanceMetric::L2SQ, Quantization::U8> {
+public:
+	using DISTANCE_TYPE = DistanceType_t<U8>;
+	using QUERY_TYPE = QuantizedVectorType_t<U8>;
+	using DATA_TYPE = DataType_t<U8>;
+
+	template <bool SKIP_PRUNED>
+	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
+	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, DISTANCE_TYPE *distances_p,
+	                     const uint32_t *pruning_positions = nullptr) {
+		for (size_t dim_idx = start_dimension; dim_idx < end_dimension; dim_idx += 4) {
+			uint32_t dimension_idx = dim_idx;
+			size_t offset_to_dimension_start = dimension_idx * total_vectors;
+			for (size_t i = 0; i < n_vectors; ++i) {
+				size_t vector_idx = i;
+				if constexpr (SKIP_PRUNED) {
+					vector_idx = pruning_positions[vector_idx];
+				}
+				int da = query[dimension_idx] - data[offset_to_dimension_start + (vector_idx * 4)];
+				int db = query[dimension_idx + 1] - data[offset_to_dimension_start + (vector_idx * 4) + 1];
+				int dc = query[dimension_idx + 2] - data[offset_to_dimension_start + (vector_idx * 4) + 2];
+				int dd = query[dimension_idx + 3] - data[offset_to_dimension_start + (vector_idx * 4) + 3];
+				distances_p[vector_idx] += (da * da) + (db * db) + (dc * dc) + (dd * dd);
+			}
+		}
+	}
+
+	static DISTANCE_TYPE Horizontal(const QUERY_TYPE *__restrict vector1, const DATA_TYPE *__restrict vector2,
+	                                size_t num_dimensions) {
+		DISTANCE_TYPE distance = 0;
+		for (size_t i = 0; i < num_dimensions; ++i) {
+			int diff = static_cast<int>(vector1[i]) - static_cast<int>(vector2[i]);
+			distance += diff * diff;
+		}
+		return distance;
+	};
+};
+
 } // namespace PDX

--- a/src/include/pdxearch/distance_computers/scalar_computers.hpp
+++ b/src/include/pdxearch/distance_computers/scalar_computers.hpp
@@ -18,7 +18,7 @@ public:
 	template <bool SKIP_PRUNED>
 	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
 	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, DISTANCE_TYPE *distances_p,
-	                     const uint32_t *pruning_positions = nullptr, const int32_t *dim_clip_value = nullptr) {
+	                     const uint32_t *pruning_positions = nullptr) {
 		size_t dimensions_jump_factor = total_vectors;
 		for (size_t dimension_idx = start_dimension; dimension_idx < end_dimension; ++dimension_idx) {
 			size_t offset_to_dimension_start = dimension_idx * dimensions_jump_factor;
@@ -34,7 +34,7 @@ public:
 	}
 
 	static DISTANCE_TYPE Horizontal(const QUERY_TYPE *__restrict vector1, const DATA_TYPE *__restrict vector2,
-	                                size_t num_dimensions, const float *scaling_factors = nullptr) {
+	                                size_t num_dimensions) {
 		DISTANCE_TYPE distance = 0.0;
 #pragma clang loop vectorize(enable)
 		for (size_t dimension_idx = 0; dimension_idx < num_dimensions; ++dimension_idx) {

--- a/src/include/pdxearch/index_base/pdx_ivf.hpp
+++ b/src/include/pdxearch/index_base/pdx_ivf.hpp
@@ -48,10 +48,10 @@ public:
 	const bool is_normalized {};
 	std::vector<float> centroids;
 
-	float quantization_scale = 1.0f;
-	float quantization_scale_squared = 1.0f;
-	float inverse_quantization_scale_squared = 1.0f;
-	float quantization_base = 0.0f;
+	const float quantization_scale = 1.0f;
+	const float quantization_scale_squared = 1.0f;
+	const float inverse_quantization_scale_squared = 1.0f;
+	const float quantization_base = 0.0f;
 
 	IndexPDXIVF(uint32_t num_dimensions, uint64_t total_num_embeddings, uint32_t num_clusters, bool is_normalized,
 	            float quantization_scale, float quantization_base)

--- a/src/include/pdxearch/index_base/pdx_ivf.hpp
+++ b/src/include/pdxearch/index_base/pdx_ivf.hpp
@@ -53,11 +53,15 @@ public:
 	float inverse_quantization_scale_squared = 1.0f;
 	float quantization_base = 0.0f;
 
-	IndexPDXIVF(uint32_t num_dimensions, uint64_t total_num_embeddings, uint32_t num_clusters, bool is_normalized, float quantization_scale, float quantization_base)
+	IndexPDXIVF(uint32_t num_dimensions, uint64_t total_num_embeddings, uint32_t num_clusters, bool is_normalized,
+	            float quantization_scale, float quantization_base)
 	    : num_dimensions(num_dimensions), total_num_embeddings(total_num_embeddings), num_clusters(num_clusters),
 	      num_vertical_dimensions(GetPDXDimensionSplit(num_dimensions).vertical_dimensions),
 	      num_horizontal_dimensions(GetPDXDimensionSplit(num_dimensions).horizontal_dimensions),
-	      is_normalized(is_normalized), quantization_scale(quantization_scale), quantization_scale_squared(quantization_scale * quantization_scale), inverse_quantization_scale_squared	(1.0f / (quantization_scale * quantization_scale)), quantization_base(quantization_base) {
+	      is_normalized(is_normalized), quantization_scale(quantization_scale),
+	      quantization_scale_squared(quantization_scale * quantization_scale),
+	      inverse_quantization_scale_squared(1.0f / (quantization_scale * quantization_scale)),
+	      quantization_base(quantization_base) {
 		clusters.reserve(num_clusters);
 	}
 };

--- a/src/include/pdxearch/index_base/pdx_ivf.hpp
+++ b/src/include/pdxearch/index_base/pdx_ivf.hpp
@@ -34,4 +34,32 @@ public:
 	}
 };
 
+template <>
+class IndexPDXIVF<U8> {
+public:
+	using CLUSTER_TYPE = Cluster<U8>;
+
+	const uint32_t num_dimensions {};
+	const uint64_t total_num_embeddings {};
+	const uint32_t num_clusters {};
+	const uint32_t num_vertical_dimensions {};
+	const uint32_t num_horizontal_dimensions {};
+	std::vector<CLUSTER_TYPE> clusters;
+	const bool is_normalized {};
+	std::vector<float> centroids;
+
+	float quantization_scale = 1.0f;
+	float quantization_scale_squared = 1.0f;
+	float inverse_quantization_scale_squared = 1.0f;
+	float quantization_base = 0.0f;
+
+	IndexPDXIVF(uint32_t num_dimensions, uint64_t total_num_embeddings, uint32_t num_clusters, bool is_normalized, float quantization_scale, float quantization_base)
+	    : num_dimensions(num_dimensions), total_num_embeddings(total_num_embeddings), num_clusters(num_clusters),
+	      num_vertical_dimensions(GetPDXDimensionSplit(num_dimensions).vertical_dimensions),
+	      num_horizontal_dimensions(GetPDXDimensionSplit(num_dimensions).horizontal_dimensions),
+	      is_normalized(is_normalized), quantization_scale(quantization_scale), quantization_scale_squared(quantization_scale * quantization_scale), inverse_quantization_scale_squared	(1.0f / (quantization_scale * quantization_scale)), quantization_base(quantization_base) {
+		clusters.reserve(num_clusters);
+	}
+};
+
 } // namespace PDX

--- a/src/include/pdxearch/pdxearch.hpp
+++ b/src/include/pdxearch/pdxearch.hpp
@@ -105,10 +105,10 @@ protected:
 	                         std::priority_queue<KNNCandidate, std::vector<KNNCandidate>, VectorComparator> &heap,
 	                         DistanceType_t<Q> &pruning_threshold, uint32_t current_dimension_idx) {
 		const std::lock_guard<std::mutex> lock(*best_k_mutex);
-		float float_threshold = pruner.GetPruningThreshold(k, heap, current_dimension_idx);
+		const float float_threshold = pruner.GetPruningThreshold(k, heap, current_dimension_idx);
 		if constexpr (Q == U8) {
 			// We need to avoid undefined behaviour when overflow happens
-			float scaled = float_threshold * pdx_data.quantization_scale_squared;
+			const float scaled = float_threshold * pdx_data.quantization_scale_squared;
 			pruning_threshold = scaled >= static_cast<float>(std::numeric_limits<DistanceType_t<Q>>::max())
 			                        ? std::numeric_limits<DistanceType_t<Q>>::max()
 			                        : static_cast<DistanceType_t<Q>>(scaled);
@@ -295,11 +295,11 @@ protected:
 	}
 
 	template <Quantization Q = q>
-	void MergeIntoHeap(const uint32_t *vector_indices, size_t n_vectors, uint32_t k, const uint32_t *pruning_positions,
-	                   DistanceType_t<Q> *pruning_distances,
+	void MergeIntoHeap(const uint32_t *vector_indices, const size_t n_vectors, const uint32_t k,
+	                   const uint32_t *pruning_positions, const DistanceType_t<Q> *pruning_distances,
 	                   std::priority_queue<KNNCandidate, std::vector<KNNCandidate>, VectorComparator> &heap) {
 		for (size_t position_idx = 0; position_idx < n_vectors; ++position_idx) {
-			size_t index = pruning_positions[position_idx];
+			const size_t index = pruning_positions[position_idx];
 			float current_distance = static_cast<float>(pruning_distances[index]);
 			if constexpr (Q == U8) {
 				current_distance *= pdx_data.inverse_quantization_scale_squared;

--- a/src/include/pdxearch/pdxearch.hpp
+++ b/src/include/pdxearch/pdxearch.hpp
@@ -100,15 +100,13 @@ protected:
 
 	// The pruning threshold by default is the top of the heap
 	template <Quantization Q = q>
-	void
-	GetPruningThreshold(uint32_t k,
-	                    std::priority_queue<KNNCandidate, std::vector<KNNCandidate>, VectorComparator> &heap,
-	                    DistanceType_t<Q> &pruning_threshold, uint32_t current_dimension_idx) {
+	void GetPruningThreshold(uint32_t k,
+	                         std::priority_queue<KNNCandidate, std::vector<KNNCandidate>, VectorComparator> &heap,
+	                         DistanceType_t<Q> &pruning_threshold, uint32_t current_dimension_idx) {
 		const std::lock_guard<std::mutex> lock(*best_k_mutex);
 		float float_threshold = pruner.GetPruningThreshold(k, heap, current_dimension_idx);
 		if constexpr (Q == U8) {
-			pruning_threshold =
-			    static_cast<DistanceType_t<Q>>(float_threshold * pdx_data.quantization_scale_squared);
+			pruning_threshold = static_cast<DistanceType_t<Q>>(float_threshold * pdx_data.quantization_scale_squared);
 		} else {
 			pruning_threshold = float_threshold;
 		}
@@ -200,8 +198,8 @@ protected:
 	            const size_t n_vectors, uint32_t k, float tuples_threshold, uint32_t *pruning_positions,
 	            DistanceType_t<Q> *pruning_distances, DistanceType_t<Q> &pruning_threshold,
 	            std::priority_queue<KNNCandidate, std::vector<KNNCandidate>, VectorComparator> &heap,
-	            uint32_t &current_dimension_idx, size_t &n_vectors_not_pruned,
-	            uint32_t passing_tuples = 0, uint8_t *selection_vector = nullptr) {
+	            uint32_t &current_dimension_idx, size_t &n_vectors_not_pruned, uint32_t passing_tuples = 0,
+	            uint8_t *selection_vector = nullptr) {
 		current_dimension_idx = 0;
 		size_t cur_subgrouping_size_idx = 0;
 		size_t tuples_needed_to_exit = static_cast<size_t>(std::ceil(tuples_threshold * static_cast<float>(n_vectors)));
@@ -332,7 +330,7 @@ public:
 		cluster_indices_in_access_order_offset = 0; // Reset cluster index offset for new search.
 		if constexpr (q == U8) {
 			quantizer.QuantizeVector(preprocessed_query, pdx_data.quantization_base, pdx_data.quantization_scale,
-			                       quantized_query_buf.get());
+			                         quantized_query_buf.get());
 			this->prepared_query = quantized_query_buf.get();
 		} else {
 			this->prepared_query = preprocessed_query;
@@ -365,8 +363,7 @@ public:
 			       pruning_positions.get(), pruning_distances.get(), pruning_threshold, *best_k, current_dimension_idx,
 			       n_vectors_not_pruned);
 			Prune(prepared_query, cluster.data, cluster.num_embeddings, k, pruning_positions.get(),
-			      pruning_distances.get(), pruning_threshold, *best_k, current_dimension_idx,
-			      n_vectors_not_pruned);
+			      pruning_distances.get(), pruning_threshold, *best_k, current_dimension_idx, n_vectors_not_pruned);
 			if (n_vectors_not_pruned) {
 				const std::lock_guard<std::mutex> lock(*best_k_mutex);
 				MergeIntoHeap(cluster.indices, n_vectors_not_pruned, k, pruning_positions.get(),
@@ -406,8 +403,7 @@ public:
 
 			Warmup<q, true>(prepared_query, cluster.data, cluster.num_embeddings, k, selectivity_threshold,
 			                pruning_positions.get(), pruning_distances.get(), pruning_threshold, *best_k,
-			                current_dimension_idx, n_vectors_not_pruned, passing_tuples,
-			                selection_vector);
+			                current_dimension_idx, n_vectors_not_pruned, passing_tuples, selection_vector);
 			Prune<q, true>(prepared_query, cluster.data, cluster.num_embeddings, k, pruning_positions.get(),
 			               pruning_distances.get(), pruning_threshold, *best_k, current_dimension_idx,
 			               n_vectors_not_pruned, selection_vector);
@@ -541,7 +537,7 @@ public:
 		QUANTIZED_VECTOR_TYPE *local_prepared_query;
 		if constexpr (q == U8) {
 			quantizer.QuantizeVector(query.get(), pdx_data.quantization_base, pdx_data.quantization_scale,
-			                       local_quantized_query.get());
+			                         local_quantized_query.get());
 			local_prepared_query = local_quantized_query.get();
 		} else {
 			local_prepared_query = query.get();
@@ -570,8 +566,7 @@ public:
 			       pruning_positions.get(), pruning_distances.get(), pruning_threshold, local_heap,
 			       current_dimension_idx, n_vectors_not_pruned);
 			Prune(local_prepared_query, cluster.data, cluster.num_embeddings, k, pruning_positions.get(),
-			      pruning_distances.get(), pruning_threshold, local_heap, current_dimension_idx,
-			      n_vectors_not_pruned);
+			      pruning_distances.get(), pruning_threshold, local_heap, current_dimension_idx, n_vectors_not_pruned);
 			if (n_vectors_not_pruned) {
 				MergeIntoHeap(cluster.indices, n_vectors_not_pruned, k, pruning_positions.get(),
 				              pruning_distances.get(), local_heap);
@@ -605,7 +600,7 @@ public:
 		QUANTIZED_VECTOR_TYPE *local_prepared_query;
 		if constexpr (q == U8) {
 			quantizer.QuantizeVector(query.get(), pdx_data.quantization_base, pdx_data.quantization_scale,
-			                       local_quantized_query.get());
+			                         local_quantized_query.get());
 			local_prepared_query = local_quantized_query.get();
 		} else {
 			local_prepared_query = query.get();
@@ -632,14 +627,13 @@ public:
 			if (local_heap.size() < k) {
 				// We cannot prune until we fill the heap
 				FilteredStart(local_prepared_query, cluster.data, cluster.num_embeddings, k, cluster.indices,
-				              pruning_positions.get(), pruning_distances.get(), local_heap,
-				              selection_vector, passing_tuples);
+				              pruning_positions.get(), pruning_distances.get(), local_heap, selection_vector,
+				              passing_tuples);
 				continue;
 			}
 			Warmup<q, true>(local_prepared_query, cluster.data, cluster.num_embeddings, k, selectivity_threshold,
 			                pruning_positions.get(), pruning_distances.get(), pruning_threshold, local_heap,
-			                current_dimension_idx, n_vectors_not_pruned, passing_tuples,
-			                selection_vector);
+			                current_dimension_idx, n_vectors_not_pruned, passing_tuples, selection_vector);
 			Prune<q, true>(local_prepared_query, cluster.data, cluster.num_embeddings, k, pruning_positions.get(),
 			               pruning_distances.get(), pruning_threshold, local_heap, current_dimension_idx,
 			               n_vectors_not_pruned, selection_vector);

--- a/src/include/pdxearch/pruners/adsampling.hpp
+++ b/src/include/pdxearch/pruners/adsampling.hpp
@@ -101,7 +101,7 @@ private:
 	void Rotate(const float *PDX_RESTRICT const embeddings, float *PDX_RESTRICT const out_buffer,
 	            const size_t n) const {
 		Eigen::Map<const MatrixR> embeddings_matrix(embeddings, static_cast<Eigen::Index>(n),
-		                                             static_cast<Eigen::Index>(num_dimensions));
+		                                            static_cast<Eigen::Index>(num_dimensions));
 		Eigen::Map<MatrixR> out(out_buffer, static_cast<Eigen::Index>(n), static_cast<Eigen::Index>(num_dimensions));
 		out.noalias() = embeddings_matrix * matrix.transpose();
 	}

--- a/src/include/pdxearch/pruners/adsampling.hpp
+++ b/src/include/pdxearch/pruners/adsampling.hpp
@@ -17,8 +17,8 @@ template <Quantization q = F32>
 class ADSamplingPruner {
 	using DISTANCES_TYPE = DistanceType_t<q>;
 	using VALUE_TYPE = DataType_t<q>;
-	using KNNCandidate_t = KNNCandidate<F32>;
-	using VectorComparator_t = VectorComparator<F32>;
+	using KNNCandidate_t = KNNCandidate;
+	using VectorComparator_t = VectorComparator;
 	using MatrixR = Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
 
 public:
@@ -56,7 +56,7 @@ public:
 
 	float GetPruningThreshold(
 	    uint32_t,
-	    std::priority_queue<KNNCandidate<F32>, std::vector<KNNCandidate<F32>>, VectorComparator<F32>> &heap,
+	    std::priority_queue<KNNCandidate, std::vector<KNNCandidate>, VectorComparator> &heap,
 	    const uint32_t current_dimension_idx) const {
 		float ratio = current_dimension_idx == num_dimensions ? 1 : ratios[current_dimension_idx];
 		return heap.top().distance * ratio;

--- a/src/include/pdxearch/pruners/adsampling.hpp
+++ b/src/include/pdxearch/pruners/adsampling.hpp
@@ -54,10 +54,9 @@ public:
 		ADSamplingPruner::matrix = matrix;
 	}
 
-	float GetPruningThreshold(
-	    uint32_t,
-	    std::priority_queue<KNNCandidate, std::vector<KNNCandidate>, VectorComparator> &heap,
-	    const uint32_t current_dimension_idx) const {
+	float GetPruningThreshold(uint32_t,
+	                          std::priority_queue<KNNCandidate, std::vector<KNNCandidate>, VectorComparator> &heap,
+	                          const uint32_t current_dimension_idx) const {
 		float ratio = current_dimension_idx == num_dimensions ? 1 : ratios[current_dimension_idx];
 		return heap.top().distance * ratio;
 	}

--- a/src/include/pdxearch/pruners/adsampling.hpp
+++ b/src/include/pdxearch/pruners/adsampling.hpp
@@ -100,8 +100,9 @@ private:
 	 */
 	void Rotate(const float *PDX_RESTRICT const embeddings, float *PDX_RESTRICT const out_buffer,
 	            const size_t n) const {
-		Eigen::Map<const MatrixR> embeddings_matrix(embeddings, n, num_dimensions);
-		Eigen::Map<MatrixR> out(out_buffer, n, num_dimensions);
+		Eigen::Map<const MatrixR> embeddings_matrix(embeddings, static_cast<Eigen::Index>(n),
+		                                             static_cast<Eigen::Index>(num_dimensions));
+		Eigen::Map<MatrixR> out(out_buffer, static_cast<Eigen::Index>(n), static_cast<Eigen::Index>(num_dimensions));
 		out.noalias() = embeddings_matrix * matrix.transpose();
 	}
 };

--- a/src/include/pdxearch/quantizers/scalar.hpp
+++ b/src/include/pdxearch/quantizers/scalar.hpp
@@ -62,7 +62,7 @@ public:
 			global_max = std::max(global_max, embeddings[i]);
 		}
 		float range = global_max - global_min;
-		return {global_min, (range > 0) ? 255.0f / range : 1.0f};
+		return {global_min, (range > 0) ? static_cast<float>(MAX_VALUE) / range : 1.0f};
 	}
 
 	void QuantizeVector(const float *input, const float quantization_base, const float quantization_scale,

--- a/src/include/pdxearch/quantizers/scalar.hpp
+++ b/src/include/pdxearch/quantizers/scalar.hpp
@@ -47,7 +47,12 @@ public:
 	explicit ScalarQuantizer(size_t num_dimensions) : Quantizer(num_dimensions) {
 	}
 
+#ifdef __AVX512F__
+	// We rely on _mm512_dpbusds_epi32 that has asymmetric operands
+	static constexpr uint8_t MAX_VALUE = 127;
+#else
 	static constexpr uint8_t MAX_VALUE = 255;
+#endif
 
 	static ScalarQuantizationParams ComputeQuantizationParams(const float *embeddings, size_t total_elements) {
 		float global_min = std::numeric_limits<float>::max();

--- a/src/index/pdxearch_index.cpp
+++ b/src/index/pdxearch_index.cpp
@@ -94,7 +94,7 @@ void PDXearchIndex::SetUpIndexForRowGroup(const row_t *const row_ids, const floa
 }
 
 void PDXearchIndex::InitializeSearchForRowGroup(float *const preprocessed_query, const idx_t limit,
-                                                const idx_t row_group_id, PDX::Heap<PDX::F32> &heap,
+                                                const idx_t row_group_id, PDX::Heap &heap,
                                                 std::mutex &heap_mutex) {
 	if (pdxearch_wrapper->GetQuantization() == PDX::U8) {
 		static_cast<PDXearchWrapperU8 *>(pdxearch_wrapper.get())
@@ -115,7 +115,7 @@ void PDXearchIndex::SearchRowGroup(const idx_t row_group_id, const idx_t num_clu
 
 void PDXearchIndex::InitializeFilteredSearchForRowGroup(float *const preprocessed_query, const idx_t limit,
                                                         const std::vector<row_t> &passing_row_ids,
-                                                        const idx_t row_group_id, PDX::Heap<PDX::F32> &heap,
+                                                        const idx_t row_group_id, PDX::Heap &heap,
                                                         std::mutex &heap_mutex) {
 	if (pdxearch_wrapper->GetQuantization() == PDX::U8) {
 		static_cast<PDXearchWrapperU8 *>(pdxearch_wrapper.get())

--- a/src/index/pdxearch_index.cpp
+++ b/src/index/pdxearch_index.cpp
@@ -94,8 +94,7 @@ void PDXearchIndex::SetUpIndexForRowGroup(const row_t *const row_ids, const floa
 }
 
 void PDXearchIndex::InitializeSearchForRowGroup(float *const preprocessed_query, const idx_t limit,
-                                                const idx_t row_group_id, PDX::Heap &heap,
-                                                std::mutex &heap_mutex) {
+                                                const idx_t row_group_id, PDX::Heap &heap, std::mutex &heap_mutex) {
 	if (pdxearch_wrapper->GetQuantization() == PDX::U8) {
 		static_cast<PDXearchWrapperU8 *>(pdxearch_wrapper.get())
 		    ->InitializeSearchForRowGroup(preprocessed_query, limit, row_group_id, heap, heap_mutex);

--- a/src/index/pdxearch_index.cpp
+++ b/src/index/pdxearch_index.cpp
@@ -69,8 +69,13 @@ PDXearchIndex::PDXearchIndex(const string &name, IndexConstraintType index_const
 		    make_uniq<PDXearchWrapperGlobalF32>(dist_metric, num_dimensions, n_probe, seed, estimated_cardinality);
 #endif
 	} else if (quantization == PDX::Quantization::U8) {
+#ifndef PDX_USE_ALTERNATIVE_GLOBAL_VERSION
 		pdxearch_wrapper =
 		    make_uniq<PDXearchWrapperU8>(dist_metric, num_dimensions, n_probe, seed, estimated_cardinality);
+#else
+		pdxearch_wrapper =
+		    make_uniq<PDXearchWrapperGlobalU8>(dist_metric, num_dimensions, n_probe, seed, estimated_cardinality);
+#endif
 	} else {
 		throw InternalException("Unsupported quantization: %s", quantization);
 	}

--- a/src/index/search/pdxearch_index_filtered_scan_physical.cpp
+++ b/src/index/search/pdxearch_index_filtered_scan_physical.cpp
@@ -38,7 +38,7 @@ public:
 		{
 			// Initialize the global heap.
 			const std::lock_guard<std::mutex> lock(global_heap_mutex);
-			global_heap = make_uniq<PDX::Heap<PDX::F32>>();
+			global_heap = make_uniq<PDX::Heap>();
 			global_heap->push(HEAP_INITIALIZATION_ELEMENT);
 		}
 
@@ -60,11 +60,11 @@ public:
 	const unique_ptr<float[]> preprocessed_query_embedding;
 
 	// Global heap shared by all threads (and row groups). Assumes the `global_heap_mutex` is used.
-	std::unique_ptr<PDX::Heap<PDX::F32>> global_heap;
+	std::unique_ptr<PDX::Heap> global_heap;
 	std::mutex global_heap_mutex;
 	// Element used to initialize the global heap. PDXearch uses the top of the heap in its operations, thus there must
 	// be an initial element. This element is always filtered out when the heap is transformed into a result set.
-	static constexpr PDX::KNNCandidate<PDX::F32> HEAP_INITIALIZATION_ELEMENT = {1337,
+	static constexpr PDX::KNNCandidate HEAP_INITIALIZATION_ELEMENT = {1337,
 	                                                                            std::numeric_limits<float>::max()};
 
 	// For iteration support:

--- a/src/index/search/pdxearch_index_filtered_scan_physical.cpp
+++ b/src/index/search/pdxearch_index_filtered_scan_physical.cpp
@@ -64,8 +64,7 @@ public:
 	std::mutex global_heap_mutex;
 	// Element used to initialize the global heap. PDXearch uses the top of the heap in its operations, thus there must
 	// be an initial element. This element is always filtered out when the heap is transformed into a result set.
-	static constexpr PDX::KNNCandidate HEAP_INITIALIZATION_ELEMENT = {1337,
-	                                                                            std::numeric_limits<float>::max()};
+	static constexpr PDX::KNNCandidate HEAP_INITIALIZATION_ELEMENT = {1337, std::numeric_limits<float>::max()};
 
 	// For iteration support:
 	// Based on the n_probe.

--- a/src/index/search/pdxearch_index_scan_physical.cpp
+++ b/src/index/search/pdxearch_index_scan_physical.cpp
@@ -36,7 +36,7 @@ public:
 		// Initialize the global heap.
 		{
 			const std::lock_guard<std::mutex> lock(global_heap_mutex);
-			global_heap = make_uniq<PDX::Heap<PDX::F32>>();
+			global_heap = make_uniq<PDX::Heap>();
 			global_heap->push(HEAP_INITIALIZATION_ELEMENT);
 		}
 
@@ -74,11 +74,11 @@ public:
 	const unique_ptr<float[]> preprocessed_query_embedding;
 
 	// Global heap shared by all threads (and row groups). Assumes the `global_heap_mutex` is used.
-	std::unique_ptr<PDX::Heap<PDX::F32>> global_heap;
+	std::unique_ptr<PDX::Heap> global_heap;
 	std::mutex global_heap_mutex;
 	// Element used to initialize the global heap. PDXearch uses the top of the heap in its operations, thus there must
 	// be an initial element. This element is always filtered out when the heap is transformed into a result set.
-	static constexpr PDX::KNNCandidate<PDX::F32> HEAP_INITIALIZATION_ELEMENT = {1337,
+	static constexpr PDX::KNNCandidate HEAP_INITIALIZATION_ELEMENT = {1337,
 	                                                                            std::numeric_limits<float>::max()};
 
 	idx_t num_clusters_to_probe_per_row_group {0};

--- a/src/index/search/pdxearch_index_scan_physical.cpp
+++ b/src/index/search/pdxearch_index_scan_physical.cpp
@@ -78,8 +78,7 @@ public:
 	std::mutex global_heap_mutex;
 	// Element used to initialize the global heap. PDXearch uses the top of the heap in its operations, thus there must
 	// be an initial element. This element is always filtered out when the heap is transformed into a result set.
-	static constexpr PDX::KNNCandidate HEAP_INITIALIZATION_ELEMENT = {1337,
-	                                                                            std::numeric_limits<float>::max()};
+	static constexpr PDX::KNNCandidate HEAP_INITIALIZATION_ELEMENT = {1337, std::numeric_limits<float>::max()};
 
 	idx_t num_clusters_to_probe_per_row_group {0};
 

--- a/test/sql/create/index_create_validate_parameters.test
+++ b/test/sql/create/index_create_validate_parameters.test
@@ -58,9 +58,9 @@ Binder Error: PDXearch index 'quantization' must be a string
 statement error
 CREATE INDEX idx ON t1 USING PDXEARCH (emb) WITH (quantization = 'test');
 ----
-Binder Error: PDXearch index 'quantization' must be one of: 'f32'
+Binder Error: PDXearch index 'quantization' must be one of: 'u8', 'f32'
 
-foreach quantization f32
+foreach quantization f32 u8
 
 statement ok
 CREATE INDEX idx ON t1 USING PDXEARCH (emb) WITH (quantization = '${quantization}');

--- a/test/sql/filtered_search/index_filtered_scan_k.test
+++ b/test/sql/filtered_search/index_filtered_scan_k.test
@@ -35,13 +35,15 @@ INSERT INTO t1 FROM read_parquet('test/assets/sift-128-euclidean-245760.parquet'
 statement ok
 CREATE TABLE t_no_index AS FROM t1;
 
+foreach quantization f32 u8
+
 foreach metric_name,distance_func l2sq,array_distance
 
 statement ok
 DROP INDEX IF EXISTS t1_idx;
 
 statement ok
-CREATE INDEX t1_idx ON t1 USING PDXEARCH (emb) WITH (metric = '${metric_name}', n_probe = ${N_PROBE});
+CREATE INDEX t1_idx ON t1 USING PDXEARCH (emb) WITH (metric = '${metric_name}', quantization = '${quantization}', n_probe = ${N_PROBE});
 
 # ============================================
 # LIMIT <= NUM_ROWS_THAT_PASS_FILTER.
@@ -74,6 +76,8 @@ query I
 SELECT (SELECT COUNT(*) FROM t2) = ${predicate_threshold};
 ----
 true
+
+endloop
 
 endloop
 

--- a/test/sql/filtered_search/index_filtered_scan_k_1.test
+++ b/test/sql/filtered_search/index_filtered_scan_k_1.test
@@ -29,13 +29,15 @@ INSERT INTO t1 FROM read_parquet('test/assets/sift-128-euclidean-245760.parquet'
 statement ok
 CREATE TABLE t_no_index AS FROM t1;
 
+foreach quantization f32 u8
+
 foreach metric_name,distance_func l2sq,array_distance cosine,array_cosine_distance ip,array_negative_inner_product
 
 statement ok
 DROP INDEX IF EXISTS t1_idx;
 
 statement ok
-CREATE INDEX t1_idx ON t1 USING PDXEARCH (emb) WITH (metric = '${metric_name}', n_probe = ${N_PROBE});
+CREATE INDEX t1_idx ON t1 USING PDXEARCH (emb) WITH (metric = '${metric_name}', quantization = '${quantization}', n_probe = ${N_PROBE});
 
 # ============================================
 # Recall is always 1.0 if only 1 row passes filter.
@@ -56,6 +58,8 @@ SELECT COUNT(*) FROM t3
     JOIN t4 USING (id);
 ----
 1
+
+endloop
 
 endloop
 

--- a/test/sql/filtered_search/index_filtered_scan_no_passing_tuples.test
+++ b/test/sql/filtered_search/index_filtered_scan_no_passing_tuples.test
@@ -35,18 +35,22 @@ SELECT COUNT(*) FROM t1 WHERE id > (${ROW_GROUP_SIZE} + ${ROW_GROUP_SIZE} - 10);
 ----
 9
 
+foreach quantization f32 u8
+
 foreach metric_name,distance_func l2sq,array_distance cosine,array_cosine_distance ip,array_negative_inner_product
 
 statement ok
 DROP INDEX IF EXISTS t1_idx;
 
 statement ok
-CREATE INDEX t1_idx ON t1 USING PDXEARCH (emb) WITH (metric = '${metric_name}', n_probe = ${N_PROBE});
+CREATE INDEX t1_idx ON t1 USING PDXEARCH (emb) WITH (metric = '${metric_name}', quantization = '${quantization}', n_probe = ${N_PROBE});
 
 # Trigger the iteration mechanism by ensuring < K (9 in this case) tuples enter the heap in the first iteration.
 # The search will conclude once all partitions have been probed (this is done in multiple iterations).
 statement ok
 SELECT * FROM t1 WHERE id > (${ROW_GROUP_SIZE} + ${ROW_GROUP_SIZE} - 10)
     ORDER BY ${distance_func}(emb, ${QUERY_EMB}::FLOAT[${DIMS}]) LIMIT ${LIMIT};
+
+endloop
 
 endloop

--- a/test/sql/search/index_scan_monotonic_recall.test
+++ b/test/sql/search/index_scan_monotonic_recall.test
@@ -25,6 +25,8 @@ CREATE OR REPLACE TABLE t1 (id INTEGER, emb FLOAT[${DIMS}]);
 statement ok
 INSERT INTO t1 FROM read_parquet('test/assets/sift-128-euclidean-245760.parquet') LIMIT ${NUM_ROWS};
 
+foreach quantization f32 u8
+
 foreach metric_name,distance_func l2sq,array_distance cosine,array_cosine_distance ip,array_negative_inner_product
 
 statement ok
@@ -34,7 +36,7 @@ statement ok
 DROP INDEX IF EXISTS t1_idx;
 
 statement ok
-CREATE INDEX t1_idx ON t1 USING PDXEARCH (emb) WITH (metric = '${metric_name}', seed = ${INDEX_SEED});
+CREATE INDEX t1_idx ON t1 USING PDXEARCH (emb) WITH (metric = '${metric_name}', quantization = '${quantization}', seed = ${INDEX_SEED});
 
 statement ok
 CREATE OR REPLACE TABLE results (n_probe INTEGER, recall FLOAT);
@@ -89,5 +91,7 @@ query I
 SELECT 0.90 <= (SELECT recall FROM results WHERE n_probe = 0);
 ----
 true
+
+endloop
 
 endloop


### PR DESCRIPTION
## Changes
- Incorporate PDX Scalar Quantization (U8)
  - This includes the implementation of AVX2 and Scalar kernels for our 8-bit layout (not implemented before) 
- Executive decision: `Heap` will always store distances as `float32`. This simplifies the management of the Heap in the PDX wrapper without needing a template parameter for Quantization.
   - Even if we eventually need heavier conversions (e.g., `float32` / `float16`), that is completely fine: The operations done to the heap are minimal. Issues would arise if we want to go to `float64`, but we will not go there, so `float32` is our catch all for the `Heap`.
 - Executive decision: We will use `U8` quantization by default.

```
Benchmarks: 
- F32: recall=0.985.  | n_probe=128 | qps = 35
- U8: recall=0.981    | n_probe=128 | qps = 51
- F32: recall=0.9272  | n_probe=28  | qps = 29
- U8: recall=0.9261   | n_probe=28  | qps= 46
```

## Let Op! 
- AVX512 and U8 kernels: I took the decision to keep the problematic intrinsic, and add a MACRO to quantize to 7-bits in AVX512 (but still storing as 8-bit), so that this does not cause issues. The difference between 8-bit and 7-bit quantization is extremely small. Therefore, this is a low priority issue, since we are not even planning to distribute AVX512 code anyways. The solution is to implement a slower kernel (similar to the AVX2 one).
