### PR TITLE
PDXification, `sgemm`, and type aliases refactoring

### DIFF
--- a/src/include/index/pdxearch_index_utils.hpp
+++ b/src/include/index/pdxearch_index_utils.hpp
@@ -73,26 +73,24 @@ StoreClusterEmbeddings<PDX::Quantization::F32, float>(PDX::IndexPDXIVF<PDX::Quan
                                                       const float *const embeddings, const size_t num_embeddings) {
 	// Store the cluster's data using the transposed PDX layout for float32 as described in:
 	// https://github.com/cwida/pdx?tab=readme-ov-file#the-data-layout
+	using matrix_t = PDX::eigen_matrix_t;
+	using h_matrix_t = Eigen::Matrix<float, Eigen::Dynamic, PDX::H_DIM_SIZE, Eigen::RowMajor>;
 
-	// Vertical dimensions.
-	for (size_t dim = 0; dim < index.num_vertical_dimensions; ++dim) {
-		for (size_t embedding = 0; embedding < num_embeddings; embedding++) {
-			cluster.data[dim * num_embeddings + embedding] = embeddings[(embedding * index.num_dimensions) + dim];
-		}
-	}
+	const auto vertical_d = index.num_vertical_dimensions;
+	const auto horizontal_d = index.num_horizontal_dimensions;
 
-	// Horizontal dimensions decomposed every 64 dimensions.
-	size_t current_horizontal_offset = index.num_vertical_dimensions * num_embeddings;
+	Eigen::Map<const matrix_t> in(embeddings, num_embeddings, index.num_dimensions);
 
-	for (size_t dim_group = 0; dim_group < index.num_horizontal_dimensions; dim_group += PDX::H_DIM_SIZE) {
-		size_t group_size = std::min(PDX::H_DIM_SIZE, index.num_horizontal_dimensions - dim_group);
-		size_t actual_dim = index.num_vertical_dimensions + dim_group;
+	// Vertical block: transpose the first vertical_d columns into dimension-major order.
+	Eigen::Map<matrix_t> out(cluster.data, vertical_d, num_embeddings);
+	out.noalias() = in.leftCols(vertical_d).transpose();
 
-		for (size_t embedding = 0; embedding < num_embeddings; embedding++) {
-			memcpy(cluster.data + current_horizontal_offset + embedding * group_size,
-			       embeddings + ((embedding * index.num_dimensions) + actual_dim), group_size * sizeof(float));
-		}
-		current_horizontal_offset += num_embeddings * group_size;
+	// Horizontal blocks: copy H_DIM_SIZE columns at a time, keeping each embedding's values contiguous.
+	float *horizontal_out = cluster.data + num_embeddings * vertical_d;
+	for (size_t j = 0; j < horizontal_d; j += PDX::H_DIM_SIZE) {
+		Eigen::Map<h_matrix_t> out_h(horizontal_out, num_embeddings, PDX::H_DIM_SIZE);
+		out_h.noalias() = in.block(0, vertical_d + j, num_embeddings, PDX::H_DIM_SIZE);
+		horizontal_out += num_embeddings * PDX::H_DIM_SIZE;
 	}
 }
 
@@ -102,46 +100,36 @@ StoreClusterEmbeddings<PDX::Quantization::U8, uint8_t>(PDX::IndexPDXIVF<PDX::Qua
                                                        const PDX::IndexPDXIVF<PDX::Quantization::U8> &index,
                                                        const uint8_t *const embeddings, const size_t num_embeddings) {
 	// Store the cluster's data using the transposed PDX layout for U8.
-	// The vertical block uses 4-way interleaving: for each group of 4 consecutive dimensions,
-	// each vector's 4 values are stored contiguously. This enables NEON vdotq_u32 processing.
+	// The vertical block uses interleaving: for each group of U8_INTERLEAVE_SIZE consecutive dimensions,
+	// each vector's values are stored contiguously. This enables NEON vdotq_u32 / AVX2 processing.
+	using u8_matrix_t = Eigen::Matrix<uint8_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+	using u8_v_matrix_t = Eigen::Matrix<uint8_t, Eigen::Dynamic, PDX::U8_INTERLEAVE_SIZE, Eigen::RowMajor>;
+	using u8_h_matrix_t = Eigen::Matrix<uint8_t, Eigen::Dynamic, PDX::H_DIM_SIZE, Eigen::RowMajor>;
 
-	// Vertical dimensions (4-way interleaved).
+	const auto vertical_d = index.num_vertical_dimensions;
+	const auto horizontal_d = index.num_horizontal_dimensions;
+
+	Eigen::Map<const u8_matrix_t> in(embeddings, num_embeddings, index.num_dimensions);
+
+	// Vertical dimensions (interleaved): copy U8_INTERLEAVE_SIZE columns at a time into row-major blocks.
 	size_t dim = 0;
-	for (; dim + 4 <= index.num_vertical_dimensions; dim += 4) {
-		for (size_t embedding = 0; embedding < num_embeddings; embedding++) {
-			cluster.data[dim * num_embeddings + embedding * 4 + 0] =
-			    embeddings[(embedding * index.num_dimensions) + dim + 0];
-			cluster.data[dim * num_embeddings + embedding * 4 + 1] =
-			    embeddings[(embedding * index.num_dimensions) + dim + 1];
-			cluster.data[dim * num_embeddings + embedding * 4 + 2] =
-			    embeddings[(embedding * index.num_dimensions) + dim + 2];
-			cluster.data[dim * num_embeddings + embedding * 4 + 3] =
-			    embeddings[(embedding * index.num_dimensions) + dim + 3];
-		}
+	for (; dim + PDX::U8_INTERLEAVE_SIZE <= vertical_d; dim += PDX::U8_INTERLEAVE_SIZE) {
+		Eigen::Map<u8_v_matrix_t> out_v(cluster.data + dim * num_embeddings, num_embeddings, PDX::U8_INTERLEAVE_SIZE);
+		out_v.noalias() = in.block(0, dim, num_embeddings, PDX::U8_INTERLEAVE_SIZE);
 	}
-	// Compact tail
-	if (dim < index.num_vertical_dimensions) {
-		auto remaining = static_cast<uint32_t>(index.num_vertical_dimensions - dim);
-		for (size_t embedding = 0; embedding < num_embeddings; embedding++) {
-			for (uint32_t k = 0; k < remaining; k++) {
-				cluster.data[dim * num_embeddings + embedding * remaining + k] =
-				    embeddings[(embedding * index.num_dimensions) + dim + k];
-			}
-		}
+	// Compact tail for remaining vertical dimensions (< U8_INTERLEAVE_SIZE).
+	if (dim < vertical_d) {
+		auto remaining = static_cast<Eigen::Index>(vertical_d - dim);
+		Eigen::Map<u8_matrix_t> out_v(cluster.data + dim * num_embeddings, num_embeddings, remaining);
+		out_v.noalias() = in.block(0, dim, num_embeddings, remaining);
 	}
 
-	// Horizontal dimensions decomposed every 64 dimensions (same layout as F32, with uint8_t).
-	size_t current_horizontal_offset = index.num_vertical_dimensions * num_embeddings;
-
-	for (size_t dim_group = 0; dim_group < index.num_horizontal_dimensions; dim_group += PDX::H_DIM_SIZE) {
-		size_t group_size = std::min(PDX::H_DIM_SIZE, static_cast<size_t>(index.num_horizontal_dimensions) - dim_group);
-		size_t actual_dim = index.num_vertical_dimensions + dim_group;
-
-		for (size_t embedding = 0; embedding < num_embeddings; embedding++) {
-			memcpy(cluster.data + current_horizontal_offset + embedding * group_size,
-			       embeddings + ((embedding * index.num_dimensions) + actual_dim), group_size * sizeof(uint8_t));
-		}
-		current_horizontal_offset += num_embeddings * group_size;
+	// Horizontal blocks: copy H_DIM_SIZE columns at a time, keeping each embedding's values contiguous.
+	uint8_t *horizontal_out = cluster.data + num_embeddings * vertical_d;
+	for (size_t j = 0; j < horizontal_d; j += PDX::H_DIM_SIZE) {
+		Eigen::Map<u8_h_matrix_t> out_h(horizontal_out, num_embeddings, PDX::H_DIM_SIZE);
+		out_h.noalias() = in.block(0, vertical_d + j, num_embeddings, PDX::H_DIM_SIZE);
+		horizontal_out += num_embeddings * PDX::H_DIM_SIZE;
 	}
 }
 

--- a/src/include/index/pdxearch_index_utils.hpp
+++ b/src/include/index/pdxearch_index_utils.hpp
@@ -34,7 +34,6 @@ namespace duckdb {
 [[nodiscard]] inline unique_ptr<float[]> GenerateRandomRotationMatrix(const size_t num_dimensions, const int32_t seed) {
 	auto rotation_matrix = make_uniq_array<float>(num_dimensions * num_dimensions);
 
-	// TODO: Confirm seed handling is sound.
 	std::mt19937 gen(seed);
 	std::normal_distribution<float> normal_dist;
 
@@ -64,8 +63,8 @@ namespace duckdb {
 // See the README of the following for a description of the PDX layout:
 // https://github.com/cwida/pdx
 template <PDX::Quantization q, typename T>
-inline void StoreClusterEmbeddings(typename PDX::IndexPDXIVF<q>::cluster_t &cluster,
-                                   const PDX::IndexPDXIVF<q> &index, const T *embeddings, const size_t num_embeddings);
+inline void StoreClusterEmbeddings(typename PDX::IndexPDXIVF<q>::cluster_t &cluster, const PDX::IndexPDXIVF<q> &index,
+                                   const T *embeddings, const size_t num_embeddings);
 
 template <>
 inline void

--- a/src/include/index/pdxearch_index_utils.hpp
+++ b/src/include/index/pdxearch_index_utils.hpp
@@ -64,12 +64,12 @@ namespace duckdb {
 // See the README of the following for a description of the PDX layout:
 // https://github.com/cwida/pdx
 template <PDX::Quantization q, typename T>
-inline void StoreClusterEmbeddings(typename PDX::IndexPDXIVF<q>::CLUSTER_TYPE &cluster,
+inline void StoreClusterEmbeddings(typename PDX::IndexPDXIVF<q>::cluster_t &cluster,
                                    const PDX::IndexPDXIVF<q> &index, const T *embeddings, const size_t num_embeddings);
 
 template <>
 inline void
-StoreClusterEmbeddings<PDX::Quantization::F32, float>(PDX::IndexPDXIVF<PDX::Quantization::F32>::CLUSTER_TYPE &cluster,
+StoreClusterEmbeddings<PDX::Quantization::F32, float>(PDX::IndexPDXIVF<PDX::Quantization::F32>::cluster_t &cluster,
                                                       const PDX::IndexPDXIVF<PDX::Quantization::F32> &index,
                                                       const float *const embeddings, const size_t num_embeddings) {
 	// Store the cluster's data using the transposed PDX layout for float32 as described in:
@@ -99,7 +99,7 @@ StoreClusterEmbeddings<PDX::Quantization::F32, float>(PDX::IndexPDXIVF<PDX::Quan
 
 template <>
 inline void
-StoreClusterEmbeddings<PDX::Quantization::U8, uint8_t>(PDX::IndexPDXIVF<PDX::Quantization::U8>::CLUSTER_TYPE &cluster,
+StoreClusterEmbeddings<PDX::Quantization::U8, uint8_t>(PDX::IndexPDXIVF<PDX::Quantization::U8>::cluster_t &cluster,
                                                        const PDX::IndexPDXIVF<PDX::Quantization::U8> &index,
                                                        const uint8_t *const embeddings, const size_t num_embeddings) {
 	// Store the cluster's data using the transposed PDX layout for U8.

--- a/src/include/index/pdxearch_wrapper.hpp
+++ b/src/include/index/pdxearch_wrapper.hpp
@@ -100,17 +100,13 @@ struct RowIdClusterMapping {
 template <PDX::Quantization Q>
 class PDXRowGroup {
 public:
-	using index_t = PDX::IndexPDXIVF<Q>;
-	using pruner_t = PDX::ADSamplingPruner<Q>;
-	using searcher_t = PDX::PDXearch<Q>;
-
 	// Row group embedding storage and metadata.
-	std::unique_ptr<index_t> index;
+	std::unique_ptr<PDX::IndexPDXIVF<Q>> index;
 	std::vector<RowIdClusterMapping> row_id_metadata {DEFAULT_ROW_GROUP_SIZE};
 
-	std::unique_ptr<pruner_t> pruner;
+	std::unique_ptr<PDX::ADSamplingPruner<Q>> pruner;
 	// The searcher is reinitialized and reused across DuckDB queries.
-	std::unique_ptr<searcher_t> searcher;
+	std::unique_ptr<PDX::PDXearch<Q>> searcher;
 };
 
 // The PDXearchWrapper for the parallel implementation. The parallel implementation uses a separate index for each row
@@ -119,11 +115,6 @@ template <PDX::Quantization Q>
 class PDXearchWrapperParallel : public PDXearchWrapper {
 public:
 	using embedding_storage_t = PDX::pdx_data_t<Q>;
-	using row_group_t = PDXRowGroup<Q>;
-	using index_ivf_t = PDX::IndexPDXIVF<Q>;
-	using pruner_t = PDX::ADSamplingPruner<Q>;
-	using searcher_t = PDX::PDXearch<Q>;
-	using quantizer_t = PDX::ScalarQuantizer<Q>;
 
 	// We aim for a 1:256 ratio of clusters to embeddings. As a DuckDB rowgroup
 	// size is usually 122880, we set 480 clusters per row group. While some
@@ -133,7 +124,7 @@ public:
 
 private:
 	uint32_t num_clusters_per_row_group {};
-	std::vector<row_group_t> row_groups;
+	std::vector<PDXRowGroup<Q>> row_groups;
 
 public:
 	PDXearchWrapperParallel(PDX::DistanceMetric distance_metric, uint32_t num_dimensions, uint32_t n_probe,
@@ -158,7 +149,7 @@ public:
 	// Initialize the wrapper's state for this row group. This is called once per row group.
 	void SetUpIndexForRowGroup(const row_t *const row_ids, const float *const embeddings, const idx_t num_embeddings,
 	                           const idx_t row_group_id) {
-		row_group_t &row_group = row_groups[row_group_id];
+		PDXRowGroup<Q> &row_group = row_groups[row_group_id];
 
 		const auto num_dimensions = GetNumDimensions();
 		// Additional constraints on the number of dimensions are enforced in `pdxearch_index_plan.cpp`.
@@ -171,17 +162,17 @@ public:
 		float quantization_base = 0.0f;
 		float quantization_scale = 1.0f;
 		if constexpr (Q == PDX::U8) {
-			const auto params = quantizer_t::ComputeQuantizationParams(embeddings, static_cast<size_t>(num_embeddings) *
-			                                                                           num_dimensions);
+			const auto params = PDX::ScalarQuantizer<Q>::ComputeQuantizationParams(
+			    embeddings, static_cast<size_t>(num_embeddings) * num_dimensions);
 			quantization_base = params.quantization_base;
 			quantization_scale = params.quantization_scale;
-			row_group.index = make_uniq<index_ivf_t>(num_dimensions, num_embeddings, num_clusters_per_row_group,
-			                                         IsNormalized(), quantization_scale, quantization_base);
+			row_group.index = make_uniq<PDX::IndexPDXIVF<Q>>(num_dimensions, num_embeddings, num_clusters_per_row_group,
+			                                                 IsNormalized(), quantization_scale, quantization_base);
 		} else {
-			row_group.index =
-			    make_uniq<index_ivf_t>(num_dimensions, num_embeddings, num_clusters_per_row_group, IsNormalized());
+			row_group.index = make_uniq<PDX::IndexPDXIVF<Q>>(num_dimensions, num_embeddings, num_clusters_per_row_group,
+			                                                 IsNormalized());
 		}
-		row_group.pruner = make_uniq<pruner_t>(num_dimensions, rotation_matrix.get());
+		row_group.pruner = make_uniq<PDX::ADSamplingPruner<Q>>(num_dimensions, rotation_matrix.get());
 
 		// Compute K-means centroids and embedding-to-centroid assignment (always on float embeddings).
 		KMeansResult kmeans_result = ComputeKMeans(embeddings, num_embeddings, num_dimensions,
@@ -214,7 +205,7 @@ public:
 				cluster.indices[position_in_cluster] = row_id;
 
 				if constexpr (Q == PDX::U8) {
-					quantizer_t quantizer(num_dimensions);
+					PDX::ScalarQuantizer<Q> quantizer(num_dimensions);
 					quantizer.QuantizeEmbedding(embeddings + (embedding_idx * num_dimensions), quantization_base,
 					                            quantization_scale,
 					                            tmp_cluster_embeddings.get() + (position_in_cluster * num_dimensions));
@@ -229,24 +220,24 @@ public:
 		}
 
 		// Note: the searcher depends on a fully initialized index in its constructor.
-		row_group.searcher = make_uniq<searcher_t>(*row_group.index, *row_group.pruner);
+		row_group.searcher = make_uniq<PDX::PDXearch<Q>>(*row_group.index, *row_group.pruner);
 	}
 
 	void InitializeSearchForRowGroup(float *const preprocessed_query_embedding, const idx_t limit,
 	                                 const idx_t row_group_id, PDX::Heap &heap, std::mutex &heap_mutex) {
-		row_group_t &row_group = row_groups[row_group_id];
+		PDXRowGroup<Q> &row_group = row_groups[row_group_id];
 		row_group.searcher->InitializeSearch(preprocessed_query_embedding, limit, heap, heap_mutex);
 	}
 
 	void SearchRowGroup(const idx_t row_group_id, const idx_t num_clusters_to_probe) {
-		row_group_t &row_group = row_groups[row_group_id];
+		PDXRowGroup<Q> &row_group = row_groups[row_group_id];
 		row_group.searcher->Search(num_clusters_to_probe);
 	}
 
 	void InitializeFilteredSearchForRowGroup(float *const preprocessed_query_embedding, const idx_t limit,
 	                                         const std::vector<row_t> &passing_row_ids, const idx_t row_group_id,
 	                                         PDX::Heap &heap, std::mutex &heap_mutex) {
-		row_group_t &row_group = row_groups[row_group_id];
+		PDXRowGroup<Q> &row_group = row_groups[row_group_id];
 
 		auto predicate_evaluator =
 		    make_uniq<PDX::PredicateEvaluator>(CreatePredicateEvaluatorForRowGroup(passing_row_ids, row_group));
@@ -256,12 +247,12 @@ public:
 	}
 
 	void FilteredSearchRowGroup(const idx_t row_group_id, const idx_t num_clusters_to_probe) {
-		row_group_t &row_group = row_groups[row_group_id];
+		PDXRowGroup<Q> &row_group = row_groups[row_group_id];
 		row_group.searcher->FilteredSearch(num_clusters_to_probe);
 	}
 
 	static PDX::PredicateEvaluator CreatePredicateEvaluatorForRowGroup(const std::vector<row_t> &passing_row_ids,
-	                                                                   const row_group_t &row_group) {
+	                                                                   const PDXRowGroup<Q> &row_group) {
 		PDX::PredicateEvaluator predicate_evaluator(row_group.index->num_clusters,
 		                                            row_group.index->total_num_embeddings);
 
@@ -292,19 +283,15 @@ template <PDX::Quantization Q>
 class PDXearchWrapperGlobal : public PDXearchWrapper {
 public:
 	using embedding_storage_t = PDX::pdx_data_t<Q>;
-	using index_ivf_t = PDX::IndexPDXIVF<Q>;
-	using pruner_t = PDX::ADSamplingPruner<Q>;
-	using searcher_t = PDX::PDXearch<Q>;
-	using quantizer_t = PDX::ScalarQuantizer<Q>;
 
 private:
 	uint32_t num_clusters {};
 	uint64_t total_num_embeddings {};
 	std::vector<RowIdClusterMapping> row_id_cluster_mapping;
 
-	std::unique_ptr<index_ivf_t> index;
-	std::unique_ptr<pruner_t> pruner;
-	std::unique_ptr<searcher_t> searcher;
+	std::unique_ptr<PDX::IndexPDXIVF<Q>> index;
+	std::unique_ptr<PDX::ADSamplingPruner<Q>> pruner;
+	std::unique_ptr<PDX::PDXearch<Q>> searcher;
 
 public:
 	PDXearchWrapperGlobal(PDX::DistanceMetric distance_metric, uint32_t num_dimensions, uint32_t n_probe, int32_t seed,
@@ -312,7 +299,7 @@ public:
 	    : PDXearchWrapper(Q, distance_metric, num_dimensions, n_probe, seed),
 	      num_clusters(ComputeNumberOfClusters(estimated_cardinality)), total_num_embeddings(estimated_cardinality),
 	      row_id_cluster_mapping(estimated_cardinality),
-	      pruner(make_uniq<pruner_t>(num_dimensions, rotation_matrix.get())) {
+	      pruner(make_uniq<PDX::ADSamplingPruner<Q>>(num_dimensions, rotation_matrix.get())) {
 		// Additional constraints on the number of dimensions are enforced in `pdxearch_index_plan.cpp`.
 		D_ASSERT(num_dimensions > 0);
 		D_ASSERT(estimated_cardinality > 0);
@@ -328,14 +315,14 @@ public:
 		float quantization_base = 0.0f;
 		float quantization_scale = 1.0f;
 		if constexpr (Q == PDX::U8) {
-			const auto params = quantizer_t::ComputeQuantizationParams(embeddings, static_cast<size_t>(num_embeddings) *
-			                                                                           num_dimensions);
+			const auto params = PDX::ScalarQuantizer<Q>::ComputeQuantizationParams(
+			    embeddings, static_cast<size_t>(num_embeddings) * num_dimensions);
 			quantization_base = params.quantization_base;
 			quantization_scale = params.quantization_scale;
-			index = make_uniq<index_ivf_t>(num_dimensions, num_embeddings, num_clusters, IsNormalized(),
-			                               quantization_scale, quantization_base);
+			index = make_uniq<PDX::IndexPDXIVF<Q>>(num_dimensions, num_embeddings, num_clusters, IsNormalized(),
+			                                       quantization_scale, quantization_base);
 		} else {
-			index = make_uniq<index_ivf_t>(num_dimensions, num_embeddings, num_clusters, IsNormalized());
+			index = make_uniq<PDX::IndexPDXIVF<Q>>(num_dimensions, num_embeddings, num_clusters, IsNormalized());
 		}
 
 		// Compute K-means centroids and embedding-to-centroid assignment (always on float embeddings).
@@ -370,7 +357,7 @@ public:
 				cluster.indices[position_in_cluster] = row_id;
 
 				if constexpr (Q == PDX::U8) {
-					quantizer_t quantizer(num_dimensions);
+					PDX::ScalarQuantizer<Q> quantizer(num_dimensions);
 					quantizer.QuantizeEmbedding(embeddings + (embedding_idx * num_dimensions), quantization_base,
 					                            quantization_scale,
 					                            tmp_cluster_embeddings.get() + (position_in_cluster * num_dimensions));
@@ -384,7 +371,7 @@ public:
 		}
 
 		// Note: the searcher depends on a fully initialized index in its constructor.
-		searcher = make_uniq<searcher_t>(*index, *pruner);
+		searcher = make_uniq<PDX::PDXearch<Q>>(*index, *pruner);
 	}
 
 	std::unique_ptr<std::vector<row_t>> Search(const float *const query_embedding, const idx_t limit,

--- a/src/include/index/pdxearch_wrapper.hpp
+++ b/src/include/index/pdxearch_wrapper.hpp
@@ -182,7 +182,7 @@ public:
 		// Row-major buffer that the current cluster's embeddings are "gathered" into. This buffer is the source for
 		// StoreClusterEmbeddings, the result of which is persistently stored in the index. The buffer is reused across
 		// clusters. For F32: buffer is float. For U8: buffer is uint8_t (quantized).
-		using EmbeddingStorageType = PDX::DataType_t<Q>;
+		using EmbeddingStorageType = PDX::pdx_data_t<Q>;
 		size_t max_cluster_size = 0;
 		for (size_t i = 0; i < num_clusters_per_row_group; i++) {
 			max_cluster_size = std::max(max_cluster_size, kmeans_result.assignments[i].size());
@@ -331,7 +331,7 @@ public:
 		// Row-major buffer that the current cluster's embeddings are "gathered" into. This buffer is the source for
 		// StoreClusterEmbeddings, the result of which is persistently stored in the index. The buffer is reused across
 		// clusters. For F32: buffer is float. For U8: buffer is uint8_t (quantized).
-		using EmbeddingStorageType = PDX::DataType_t<Q>;
+		using EmbeddingStorageType = PDX::pdx_data_t<Q>;
 		size_t max_cluster_size = 0;
 		for (size_t i = 0; i < num_clusters; i++) {
 			max_cluster_size = std::max(max_cluster_size, kmeans_result.assignments[i].size());

--- a/src/include/pdxearch/common.hpp
+++ b/src/include/pdxearch/common.hpp
@@ -66,7 +66,7 @@ struct DistanceType<F32> {
 	using type = float;
 };
 template <Quantization q>
-using DistanceType_t = typename DistanceType<q>::type;
+using pdx_distance_t = typename DistanceType<q>::type;
 
 // TODO: Do the same for indexes?
 template <Quantization q>
@@ -78,7 +78,7 @@ struct DataType<F32> {
 	using type = float;
 };
 template <Quantization q>
-using DataType_t = typename DataType<q>::type;
+using pdx_data_t = typename DataType<q>::type;
 
 template <Quantization q>
 struct QuantizedVectorType {
@@ -89,7 +89,7 @@ struct QuantizedVectorType<F32> {
 	using type = float;
 };
 template <Quantization q>
-using QuantizedEmbeddingType_t = typename QuantizedVectorType<q>::type;
+using pdx_quantized_embedding_t = typename QuantizedVectorType<q>::type;
 
 struct KNNCandidate {
 	uint32_t index;
@@ -104,7 +104,7 @@ struct VectorComparator {
 
 template <Quantization q>
 struct Cluster {
-	using data_t = DataType_t<q>;
+	using data_t = pdx_data_t<q>;
 
 	Cluster(uint32_t num_embeddings, uint32_t num_dimensions)
 	    : num_embeddings(num_embeddings), indices(new uint32_t[num_embeddings]),

--- a/src/include/pdxearch/common.hpp
+++ b/src/include/pdxearch/common.hpp
@@ -57,7 +57,7 @@ enum class DistanceMetric { L2SQ, COSINE, IP };
 enum Quantization { F32, U8, F16, BF };
 
 // TODO: Do the same for indexes?
-template <Quantization q>
+template <Quantization Q>
 struct DistanceType {
 	using type = uint32_t;
 };
@@ -65,11 +65,11 @@ template <>
 struct DistanceType<F32> {
 	using type = float;
 };
-template <Quantization q>
-using pdx_distance_t = typename DistanceType<q>::type;
+template <Quantization Q>
+using pdx_distance_t = typename DistanceType<Q>::type;
 
 // TODO: Do the same for indexes?
-template <Quantization q>
+template <Quantization Q>
 struct DataType {
 	using type = uint8_t; // U8
 };
@@ -77,10 +77,10 @@ template <>
 struct DataType<F32> {
 	using type = float;
 };
-template <Quantization q>
-using pdx_data_t = typename DataType<q>::type;
+template <Quantization Q>
+using pdx_data_t = typename DataType<Q>::type;
 
-template <Quantization q>
+template <Quantization Q>
 struct QuantizedVectorType {
 	using type = uint8_t; // U8
 };
@@ -88,8 +88,8 @@ template <>
 struct QuantizedVectorType<F32> {
 	using type = float;
 };
-template <Quantization q>
-using pdx_quantized_embedding_t = typename QuantizedVectorType<q>::type;
+template <Quantization Q>
+using pdx_quantized_embedding_t = typename QuantizedVectorType<Q>::type;
 
 struct KNNCandidate {
 	uint32_t index;
@@ -102,9 +102,9 @@ struct VectorComparator {
 	}
 };
 
-template <Quantization q>
+template <Quantization Q>
 struct Cluster {
-	using data_t = pdx_data_t<q>;
+	using data_t = pdx_data_t<Q>;
 
 	Cluster(uint32_t num_embeddings, uint32_t num_dimensions)
 	    : num_embeddings(num_embeddings), indices(new uint32_t[num_embeddings]),

--- a/src/include/pdxearch/distance_computers/avx2_computers.hpp
+++ b/src/include/pdxearch/distance_computers/avx2_computers.hpp
@@ -7,7 +7,7 @@
 
 namespace PDX {
 
-template <DistanceMetric alpha, Quantization q>
+template <DistanceMetric alpha, Quantization Q>
 class SIMDComputer {};
 
 template <>
@@ -19,7 +19,7 @@ public:
 	using scalar_computer = ScalarComputer<DistanceMetric::L2SQ, Quantization::F32>;
 
 	template <bool SKIP_PRUNED>
-	static void Vertical(const query_t *__restrict query, const data_t *__restrict data, size_t n_vectors,
+	static void Vertical(const query_t *PDX_RESTRICT query, const data_t *PDX_RESTRICT data, size_t n_vectors,
 	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, distance_t *distances_p,
 	                     const uint32_t *pruning_positions = nullptr) {
 		size_t dimensions_jump_factor = total_vectors;
@@ -36,8 +36,8 @@ public:
 		}
 	}
 
-	static distance_t Horizontal(const query_t *__restrict vector1, const data_t *__restrict vector2,
-	                                size_t num_dimensions) {
+	static distance_t Horizontal(const query_t *PDX_RESTRICT vector1, const data_t *PDX_RESTRICT vector2,
+	                             size_t num_dimensions) {
 		__m256 d2_vec = _mm256_setzero_ps();
 		size_t i = 0;
 		for (; i + 8 <= num_dimensions; i += 8) {
@@ -88,7 +88,7 @@ public:
 	using data_t = pdx_data_t<U8>;
 
 	template <bool SKIP_PRUNED>
-	static void Vertical(const query_t *__restrict query, const data_t *__restrict data, size_t n_vectors,
+	static void Vertical(const query_t *PDX_RESTRICT query, const data_t *PDX_RESTRICT data, size_t n_vectors,
 	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, distance_t *distances_p,
 	                     const uint32_t *pruning_positions = nullptr) {
 		auto *query_grouped = reinterpret_cast<const uint32_t *>(query);
@@ -147,8 +147,8 @@ public:
 		}
 	}
 
-	static distance_t Horizontal(const query_t *__restrict vector1, const data_t *__restrict vector2,
-	                                size_t num_dimensions) {
+	static distance_t Horizontal(const query_t *PDX_RESTRICT vector1, const data_t *PDX_RESTRICT vector2,
+	                             size_t num_dimensions) {
 		__m256i d2_vec = _mm256_setzero_si256();
 		__m256i zeros = _mm256_setzero_si256();
 		size_t i = 0;

--- a/src/include/pdxearch/distance_computers/avx2_computers.hpp
+++ b/src/include/pdxearch/distance_computers/avx2_computers.hpp
@@ -13,14 +13,14 @@ class SIMDComputer {};
 template <>
 class SIMDComputer<DistanceMetric::L2SQ, Quantization::F32> {
 public:
-	using DISTANCE_TYPE = DistanceType_t<F32>;
-	using QUERY_TYPE = QuantizedEmbeddingType_t<F32>;
-	using DATA_TYPE = DataType_t<F32>;
+	using distance_t = pdx_distance_t<F32>;
+	using query_t = pdx_quantized_embedding_t<F32>;
+	using data_t = pdx_data_t<F32>;
 	using scalar_computer = ScalarComputer<DistanceMetric::L2SQ, Quantization::F32>;
 
 	template <bool SKIP_PRUNED>
-	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
-	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, DISTANCE_TYPE *distances_p,
+	static void Vertical(const query_t *__restrict query, const data_t *__restrict data, size_t n_vectors,
+	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, distance_t *distances_p,
 	                     const uint32_t *pruning_positions = nullptr) {
 		size_t dimensions_jump_factor = total_vectors;
 		for (size_t dimension_idx = start_dimension; dimension_idx < end_dimension; ++dimension_idx) {
@@ -30,13 +30,13 @@ public:
 				if constexpr (SKIP_PRUNED) {
 					true_vector_idx = pruning_positions[vector_idx];
 				}
-				DISTANCE_TYPE to_multiply = query[dimension_idx] - data[offset_to_dimension_start + true_vector_idx];
+				distance_t to_multiply = query[dimension_idx] - data[offset_to_dimension_start + true_vector_idx];
 				distances_p[true_vector_idx] += to_multiply * to_multiply;
 			}
 		}
 	}
 
-	static DISTANCE_TYPE Horizontal(const QUERY_TYPE *__restrict vector1, const DATA_TYPE *__restrict vector2,
+	static distance_t Horizontal(const query_t *__restrict vector1, const data_t *__restrict vector2,
 	                                size_t num_dimensions) {
 		__m256 d2_vec = _mm256_setzero_ps();
 		size_t i = 0;
@@ -72,24 +72,24 @@ public:
 		double d2 = _mm_cvtsd_f64(sum128);
 
 		for (; i < num_dimensions; ++i) {
-			DISTANCE_TYPE d = vector1[i] - vector2[i];
+			distance_t d = vector1[i] - vector2[i];
 			d2 += d * d;
 		}
 
-		return static_cast<DISTANCE_TYPE>(d2);
+		return static_cast<distance_t>(d2);
 	};
 };
 
 template <>
 class SIMDComputer<DistanceMetric::L2SQ, Quantization::U8> {
 public:
-	using DISTANCE_TYPE = DistanceType_t<U8>;
-	using QUERY_TYPE = QuantizedEmbeddingType_t<U8>;
-	using DATA_TYPE = DataType_t<U8>;
+	using distance_t = pdx_distance_t<U8>;
+	using query_t = pdx_quantized_embedding_t<U8>;
+	using data_t = pdx_data_t<U8>;
 
 	template <bool SKIP_PRUNED>
-	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
-	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, DISTANCE_TYPE *distances_p,
+	static void Vertical(const query_t *__restrict query, const data_t *__restrict data, size_t n_vectors,
+	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, distance_t *distances_p,
 	                     const uint32_t *pruning_positions = nullptr) {
 		auto *query_grouped = reinterpret_cast<const uint32_t *>(query);
 		size_t dim_idx = start_dimension;
@@ -147,7 +147,7 @@ public:
 		}
 	}
 
-	static DISTANCE_TYPE Horizontal(const QUERY_TYPE *__restrict vector1, const DATA_TYPE *__restrict vector2,
+	static distance_t Horizontal(const query_t *__restrict vector1, const data_t *__restrict vector2,
 	                                size_t num_dimensions) {
 		__m256i d2_vec = _mm256_setzero_si256();
 		__m256i zeros = _mm256_setzero_si256();
@@ -167,7 +167,7 @@ public:
 		__m128i sum128 = _mm_add_epi32(lo, hi);
 		sum128 = _mm_hadd_epi32(sum128, sum128);
 		sum128 = _mm_hadd_epi32(sum128, sum128);
-		DISTANCE_TYPE distance = _mm_cvtsi128_si32(sum128);
+		distance_t distance = _mm_cvtsi128_si32(sum128);
 		// Scalar tail.
 		for (; i < num_dimensions; ++i) {
 			int n = static_cast<int>(vector1[i]) - static_cast<int>(vector2[i]);

--- a/src/include/pdxearch/distance_computers/avx512_computers.hpp
+++ b/src/include/pdxearch/distance_computers/avx512_computers.hpp
@@ -13,13 +13,13 @@ class SIMDComputer {};
 template <>
 class SIMDComputer<DistanceMetric::L2SQ, Quantization::F32> {
 public:
-	using DISTANCE_TYPE = DistanceType_t<F32>;
-	using QUERY_TYPE = QuantizedEmbeddingType_t<F32>;
-	using DATA_TYPE = DataType_t<F32>;
+	using distance_t = pdx_distance_t<F32>;
+	using query_t = pdx_quantized_embedding_t<F32>;
+	using data_t = pdx_data_t<F32>;
 
 	template <bool SKIP_PRUNED>
-	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
-	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, DISTANCE_TYPE *distances_p,
+	static void Vertical(const query_t *__restrict query, const data_t *__restrict data, size_t n_vectors,
+	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, distance_t *distances_p,
 	                     const uint32_t *pruning_positions = nullptr) {
 		size_t dimensions_jump_factor = total_vectors;
 		for (size_t dimension_idx = start_dimension; dimension_idx < end_dimension; ++dimension_idx) {
@@ -29,13 +29,13 @@ public:
 				if constexpr (SKIP_PRUNED) {
 					true_vector_idx = pruning_positions[vector_idx];
 				}
-				DISTANCE_TYPE to_multiply = query[dimension_idx] - data[offset_to_dimension_start + true_vector_idx];
+				distance_t to_multiply = query[dimension_idx] - data[offset_to_dimension_start + true_vector_idx];
 				distances_p[true_vector_idx] += to_multiply * to_multiply;
 			}
 		}
 	}
 
-	static DISTANCE_TYPE Horizontal(const QUERY_TYPE *__restrict vector1, const DATA_TYPE *__restrict vector2,
+	static distance_t Horizontal(const query_t *__restrict vector1, const data_t *__restrict vector2,
 	                                size_t num_dimensions) {
 		__m512 d2_vec = _mm512_setzero();
 		__m512 a_vec, b_vec;
@@ -67,13 +67,13 @@ public:
 template <>
 class SIMDComputer<DistanceMetric::L2SQ, Quantization::U8> {
 public:
-	using DISTANCE_TYPE = DistanceType_t<U8>;
-	using QUERY_TYPE = QuantizedEmbeddingType_t<U8>;
-	using DATA_TYPE = DataType_t<U8>;
+	using distance_t = pdx_distance_t<U8>;
+	using query_t = pdx_quantized_embedding_t<U8>;
+	using data_t = pdx_data_t<U8>;
 
 	template <bool SKIP_PRUNED>
-	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
-	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, DISTANCE_TYPE *distances_p,
+	static void Vertical(const query_t *__restrict query, const data_t *__restrict data, size_t n_vectors,
+	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, distance_t *distances_p,
 	                     const uint32_t *pruning_positions = nullptr) {
 		__m512i res;
 		__m512i vec2_u8;
@@ -147,7 +147,7 @@ public:
 		}
 	}
 
-	static DISTANCE_TYPE Horizontal(const QUERY_TYPE *__restrict vector1, const DATA_TYPE *__restrict vector2,
+	static distance_t Horizontal(const query_t *__restrict vector1, const data_t *__restrict vector2,
 	                                size_t num_dimensions) {
 		__m512i d2_i32_vec = _mm512_setzero_si512();
 		__m512i a_u8_vec, b_u8_vec;

--- a/src/include/pdxearch/distance_computers/avx512_computers.hpp
+++ b/src/include/pdxearch/distance_computers/avx512_computers.hpp
@@ -7,7 +7,7 @@
 
 namespace PDX {
 
-template <DistanceMetric alpha, Quantization q>
+template <DistanceMetric alpha, Quantization Q>
 class SIMDComputer {};
 
 template <>
@@ -18,7 +18,7 @@ public:
 	using data_t = pdx_data_t<F32>;
 
 	template <bool SKIP_PRUNED>
-	static void Vertical(const query_t *__restrict query, const data_t *__restrict data, size_t n_vectors,
+	static void Vertical(const query_t *PDX_RESTRICT query, const data_t *PDX_RESTRICT data, size_t n_vectors,
 	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, distance_t *distances_p,
 	                     const uint32_t *pruning_positions = nullptr) {
 		size_t dimensions_jump_factor = total_vectors;
@@ -35,8 +35,8 @@ public:
 		}
 	}
 
-	static distance_t Horizontal(const query_t *__restrict vector1, const data_t *__restrict vector2,
-	                                size_t num_dimensions) {
+	static distance_t Horizontal(const query_t *PDX_RESTRICT vector1, const data_t *PDX_RESTRICT vector2,
+	                             size_t num_dimensions) {
 		__m512 d2_vec = _mm512_setzero();
 		__m512 a_vec, b_vec;
 	simsimd_l2sq_f32_skylake_cycle:
@@ -72,7 +72,7 @@ public:
 	using data_t = pdx_data_t<U8>;
 
 	template <bool SKIP_PRUNED>
-	static void Vertical(const query_t *__restrict query, const data_t *__restrict data, size_t n_vectors,
+	static void Vertical(const query_t *PDX_RESTRICT query, const data_t *PDX_RESTRICT data, size_t n_vectors,
 	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, distance_t *distances_p,
 	                     const uint32_t *pruning_positions = nullptr) {
 		__m512i res;
@@ -147,8 +147,8 @@ public:
 		}
 	}
 
-	static distance_t Horizontal(const query_t *__restrict vector1, const data_t *__restrict vector2,
-	                                size_t num_dimensions) {
+	static distance_t Horizontal(const query_t *PDX_RESTRICT vector1, const data_t *PDX_RESTRICT vector2,
+	                             size_t num_dimensions) {
 		__m512i d2_i32_vec = _mm512_setzero_si512();
 		__m512i a_u8_vec, b_u8_vec;
 

--- a/src/include/pdxearch/distance_computers/base_computers.hpp
+++ b/src/include/pdxearch/distance_computers/base_computers.hpp
@@ -23,7 +23,7 @@
 
 namespace PDX {
 
-template <DistanceMetric alpha, Quantization q>
+template <DistanceMetric alpha, Quantization Q>
 class DistanceComputer {};
 
 template <>

--- a/src/include/pdxearch/distance_computers/neon_computers.hpp
+++ b/src/include/pdxearch/distance_computers/neon_computers.hpp
@@ -6,7 +6,7 @@
 
 namespace PDX {
 
-template <DistanceMetric alpha, Quantization q>
+template <DistanceMetric alpha, Quantization Q>
 class SIMDComputer {};
 
 template <>
@@ -17,7 +17,7 @@ public:
 	using data_t = pdx_data_t<F32>;
 
 	template <bool SKIP_PRUNED>
-	static void Vertical(const query_t *__restrict query, const data_t *__restrict data, size_t n_vectors,
+	static void Vertical(const query_t *PDX_RESTRICT query, const data_t *PDX_RESTRICT data, size_t n_vectors,
 	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, distance_t *distances_p,
 	                     const uint32_t *pruning_positions = nullptr) {
 		size_t dimensions_jump_factor = total_vectors;
@@ -34,8 +34,8 @@ public:
 		}
 	}
 
-	static distance_t Horizontal(const query_t *__restrict vector1, const data_t *__restrict vector2,
-	                                size_t num_dimensions) {
+	static distance_t Horizontal(const query_t *PDX_RESTRICT vector1, const data_t *PDX_RESTRICT vector2,
+	                             size_t num_dimensions) {
 #if defined(__APPLE__)
 		distance_t distance = 0.0;
 #pragma clang loop vectorize(enable)
@@ -84,7 +84,7 @@ public:
 	using data_t = pdx_data_t<U8>;
 
 	template <bool SKIP_PRUNED>
-	static void Vertical(const query_t *__restrict query, const data_t *__restrict data, size_t n_vectors,
+	static void Vertical(const query_t *PDX_RESTRICT query, const data_t *PDX_RESTRICT data, size_t n_vectors,
 	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, distance_t *distances_p,
 	                     const uint32_t *pruning_positions = nullptr) {
 		size_t dim_idx = start_dimension;
@@ -134,8 +134,8 @@ public:
 		}
 	}
 
-	static distance_t Horizontal(const query_t *__restrict vector1, const data_t *__restrict vector2,
-	                                size_t num_dimensions) {
+	static distance_t Horizontal(const query_t *PDX_RESTRICT vector1, const data_t *PDX_RESTRICT vector2,
+	                             size_t num_dimensions) {
 		uint32x4_t sum_vec = vdupq_n_u32(0);
 		size_t i = 0;
 		for (; i + 16 <= num_dimensions; i += 16) {

--- a/src/include/pdxearch/distance_computers/scalar_computers.hpp
+++ b/src/include/pdxearch/distance_computers/scalar_computers.hpp
@@ -5,7 +5,7 @@
 
 namespace PDX {
 
-template <DistanceMetric alpha, Quantization q>
+template <DistanceMetric alpha, Quantization Q>
 class ScalarComputer {};
 
 template <>
@@ -16,7 +16,7 @@ public:
 	using data_t = pdx_data_t<F32>;
 
 	template <bool SKIP_PRUNED>
-	static void Vertical(const query_t *__restrict query, const data_t *__restrict data, size_t n_vectors,
+	static void Vertical(const query_t *PDX_RESTRICT query, const data_t *PDX_RESTRICT data, size_t n_vectors,
 	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, distance_t *distances_p,
 	                     const uint32_t *pruning_positions = nullptr) {
 		size_t dimensions_jump_factor = total_vectors;
@@ -33,8 +33,8 @@ public:
 		}
 	}
 
-	static distance_t Horizontal(const query_t *__restrict vector1, const data_t *__restrict vector2,
-	                                size_t num_dimensions) {
+	static distance_t Horizontal(const query_t *PDX_RESTRICT vector1, const data_t *PDX_RESTRICT vector2,
+	                             size_t num_dimensions) {
 		distance_t distance = 0.0;
 #pragma clang loop vectorize(enable)
 		for (size_t dimension_idx = 0; dimension_idx < num_dimensions; ++dimension_idx) {
@@ -53,7 +53,7 @@ public:
 	using data_t = pdx_data_t<U8>;
 
 	template <bool SKIP_PRUNED>
-	static void Vertical(const query_t *__restrict query, const data_t *__restrict data, size_t n_vectors,
+	static void Vertical(const query_t *PDX_RESTRICT query, const data_t *PDX_RESTRICT data, size_t n_vectors,
 	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, distance_t *distances_p,
 	                     const uint32_t *pruning_positions = nullptr) {
 		size_t dim_idx = start_dimension;
@@ -88,8 +88,8 @@ public:
 		}
 	}
 
-	static distance_t Horizontal(const query_t *__restrict vector1, const data_t *__restrict vector2,
-	                                size_t num_dimensions) {
+	static distance_t Horizontal(const query_t *PDX_RESTRICT vector1, const data_t *PDX_RESTRICT vector2,
+	                             size_t num_dimensions) {
 		distance_t distance = 0;
 		for (size_t i = 0; i < num_dimensions; ++i) {
 			int diff = static_cast<int>(vector1[i]) - static_cast<int>(vector2[i]);

--- a/src/include/pdxearch/distance_computers/scalar_computers.hpp
+++ b/src/include/pdxearch/distance_computers/scalar_computers.hpp
@@ -11,13 +11,13 @@ class ScalarComputer {};
 template <>
 class ScalarComputer<DistanceMetric::L2SQ, Quantization::F32> {
 public:
-	using DISTANCE_TYPE = DistanceType_t<F32>;
-	using QUERY_TYPE = QuantizedEmbeddingType_t<F32>;
-	using DATA_TYPE = DataType_t<F32>;
+	using distance_t = pdx_distance_t<F32>;
+	using query_t = pdx_quantized_embedding_t<F32>;
+	using data_t = pdx_data_t<F32>;
 
 	template <bool SKIP_PRUNED>
-	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
-	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, DISTANCE_TYPE *distances_p,
+	static void Vertical(const query_t *__restrict query, const data_t *__restrict data, size_t n_vectors,
+	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, distance_t *distances_p,
 	                     const uint32_t *pruning_positions = nullptr) {
 		size_t dimensions_jump_factor = total_vectors;
 		for (size_t dimension_idx = start_dimension; dimension_idx < end_dimension; ++dimension_idx) {
@@ -27,18 +27,18 @@ public:
 				if constexpr (SKIP_PRUNED) {
 					true_vector_idx = pruning_positions[vector_idx];
 				}
-				DISTANCE_TYPE to_multiply = query[dimension_idx] - data[offset_to_dimension_start + true_vector_idx];
+				distance_t to_multiply = query[dimension_idx] - data[offset_to_dimension_start + true_vector_idx];
 				distances_p[true_vector_idx] += to_multiply * to_multiply;
 			}
 		}
 	}
 
-	static DISTANCE_TYPE Horizontal(const QUERY_TYPE *__restrict vector1, const DATA_TYPE *__restrict vector2,
+	static distance_t Horizontal(const query_t *__restrict vector1, const data_t *__restrict vector2,
 	                                size_t num_dimensions) {
-		DISTANCE_TYPE distance = 0.0;
+		distance_t distance = 0.0;
 #pragma clang loop vectorize(enable)
 		for (size_t dimension_idx = 0; dimension_idx < num_dimensions; ++dimension_idx) {
-			DISTANCE_TYPE to_multiply = vector1[dimension_idx] - vector2[dimension_idx];
+			distance_t to_multiply = vector1[dimension_idx] - vector2[dimension_idx];
 			distance += to_multiply * to_multiply;
 		}
 		return distance;
@@ -48,13 +48,13 @@ public:
 template <>
 class ScalarComputer<DistanceMetric::L2SQ, Quantization::U8> {
 public:
-	using DISTANCE_TYPE = DistanceType_t<U8>;
-	using QUERY_TYPE = QuantizedEmbeddingType_t<U8>;
-	using DATA_TYPE = DataType_t<U8>;
+	using distance_t = pdx_distance_t<U8>;
+	using query_t = pdx_quantized_embedding_t<U8>;
+	using data_t = pdx_data_t<U8>;
 
 	template <bool SKIP_PRUNED>
-	static void Vertical(const QUERY_TYPE *__restrict query, const DATA_TYPE *__restrict data, size_t n_vectors,
-	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, DISTANCE_TYPE *distances_p,
+	static void Vertical(const query_t *__restrict query, const data_t *__restrict data, size_t n_vectors,
+	                     size_t total_vectors, size_t start_dimension, size_t end_dimension, distance_t *distances_p,
 	                     const uint32_t *pruning_positions = nullptr) {
 		size_t dim_idx = start_dimension;
 		for (; dim_idx + 4 <= end_dimension; dim_idx += 4) {
@@ -88,9 +88,9 @@ public:
 		}
 	}
 
-	static DISTANCE_TYPE Horizontal(const QUERY_TYPE *__restrict vector1, const DATA_TYPE *__restrict vector2,
+	static distance_t Horizontal(const query_t *__restrict vector1, const data_t *__restrict vector2,
 	                                size_t num_dimensions) {
-		DISTANCE_TYPE distance = 0;
+		distance_t distance = 0;
 		for (size_t i = 0; i < num_dimensions; ++i) {
 			int diff = static_cast<int>(vector1[i]) - static_cast<int>(vector2[i]);
 			distance += diff * diff;

--- a/src/include/pdxearch/index_base/pdx_ivf.hpp
+++ b/src/include/pdxearch/index_base/pdx_ivf.hpp
@@ -14,14 +14,14 @@ class IndexPDXIVF {};
 template <>
 class IndexPDXIVF<F32> {
 public:
-	using CLUSTER_TYPE = Cluster<F32>;
+	using cluster_t = Cluster<F32>;
 
 	const uint32_t num_dimensions {};
 	const uint64_t total_num_embeddings {};
 	const uint32_t num_clusters {};
 	const uint32_t num_vertical_dimensions {};
 	const uint32_t num_horizontal_dimensions {};
-	std::vector<CLUSTER_TYPE> clusters;
+	std::vector<cluster_t> clusters;
 	const bool is_normalized {};
 	std::vector<float> centroids;
 
@@ -37,14 +37,14 @@ public:
 template <>
 class IndexPDXIVF<U8> {
 public:
-	using CLUSTER_TYPE = Cluster<U8>;
+	using cluster_t = Cluster<U8>;
 
 	const uint32_t num_dimensions {};
 	const uint64_t total_num_embeddings {};
 	const uint32_t num_clusters {};
 	const uint32_t num_vertical_dimensions {};
 	const uint32_t num_horizontal_dimensions {};
-	std::vector<CLUSTER_TYPE> clusters;
+	std::vector<cluster_t> clusters;
 	const bool is_normalized {};
 	std::vector<float> centroids;
 

--- a/src/include/pdxearch/index_base/pdx_ivf.hpp
+++ b/src/include/pdxearch/index_base/pdx_ivf.hpp
@@ -8,7 +8,7 @@
 
 namespace PDX {
 
-template <Quantization q>
+template <Quantization Q>
 class IndexPDXIVF {};
 
 template <>

--- a/src/include/pdxearch/pdxearch.hpp
+++ b/src/include/pdxearch/pdxearch.hpp
@@ -19,22 +19,22 @@ template <Quantization q = F32, class Index = IndexPDXIVF<q>, class Quantizer = 
           DistanceMetric alpha = DistanceMetric::L2SQ, class Pruner = ADSamplingPruner<q>>
 class PDXearch {
 public:
-	using DISTANCES_TYPE = DistanceType_t<q>;
-	using QUANTIZED_EMBEDDING_TYPE = QuantizedEmbeddingType_t<q>;
-	using INDEX_TYPE = Index;
-	using CLUSTER_TYPE = Cluster<q>;
-	using KNNCandidate_t = KNNCandidate;
-	using VectorComparator_t = VectorComparator;
+	using distance_t = pdx_distance_t<q>;
+	using data_t = pdx_data_t<q>;
+	using quantized_embedding_t = pdx_quantized_embedding_t<q>;
+	using index_t = Index;
+	using cluster_t = Cluster<q>;
+	using distance_computer_t = DistanceComputer<alpha, q>;
 
 	Quantizer quantizer;
 	Pruner &pruner;
-	INDEX_TYPE &pdx_data;
+	index_t &pdx_data;
 
-	PDXearch(INDEX_TYPE &data_index, Pruner &pruner)
+	PDXearch(index_t &data_index, Pruner &pruner)
 	    : quantizer(data_index.num_dimensions), pruner(pruner), pdx_data(data_index),
 	      cluster_offsets(new size_t[data_index.num_clusters]),
 	      cluster_indices_in_access_order(new uint32_t[data_index.num_clusters]),
-	      quantized_query_buf(new QUANTIZED_EMBEDDING_TYPE[data_index.num_dimensions]) {
+	      quantized_query_buf(new quantized_embedding_t[data_index.num_dimensions]) {
 		for (size_t i = 0; i < data_index.num_clusters; ++i) {
 			cluster_offsets[i] = total_embeddings;
 			total_embeddings += data_index.clusters[i].num_embeddings;
@@ -46,16 +46,16 @@ public:
 		ivf_nprobe = nprobe;
 	}
 
-	[[nodiscard]] static std::vector<KNNCandidate_t>
+	[[nodiscard]] static std::vector<KNNCandidate>
 	BuildResultSetFromHeap(uint32_t k,
-	                       std::priority_queue<KNNCandidate_t, std::vector<KNNCandidate_t>, VectorComparator_t> &heap) {
+	                       std::priority_queue<KNNCandidate, std::vector<KNNCandidate>, VectorComparator> &heap) {
 		// Pop the initialization element from the heap, as it can't be part of the result.
 		if (!heap.empty() && heap.top().distance == std::numeric_limits<float>::max()) {
 			heap.pop();
 		}
 
 		size_t result_set_size = std::min(heap.size(), static_cast<size_t>(k));
-		std::vector<KNNCandidate_t> result;
+		std::vector<KNNCandidate> result;
 		result.resize(result_set_size);
 		for (size_t i = result_set_size; i > 0; --i) {
 			result[i - 1] = heap.top();
@@ -82,7 +82,7 @@ protected:
 
 	// Start: State for the current filtered search.
 	uint32_t k = 0;
-	QUANTIZED_EMBEDDING_TYPE *prepared_query = nullptr;
+	quantized_embedding_t *prepared_query = nullptr;
 	// Predicate evaluator for this rowgroup.
 	std::unique_ptr<PredicateEvaluator> predicate_evaluator;
 	// End
@@ -92,43 +92,39 @@ protected:
 
 	// Per-search query buffers, filled by QuantizeEmbedding in InitializeSearch (U8 path).
 	// Used by Search/FilteredSearch and passed to Warmup/Prune.
-	std::unique_ptr<QUANTIZED_EMBEDDING_TYPE[]> quantized_query_buf;
+	std::unique_ptr<quantized_embedding_t[]> quantized_query_buf;
 
-	template <Quantization Q = q>
-	void ResetPruningDistances(size_t n_vectors, DistanceType_t<Q> *pruning_distances) {
-		std::fill(pruning_distances, pruning_distances + n_vectors, DistanceType_t<Q> {0});
+	void ResetPruningDistances(size_t n_vectors, distance_t *pruning_distances) {
+		std::fill(pruning_distances, pruning_distances + n_vectors, distance_t {0});
 	}
 
 	// The pruning threshold by default is the top of the heap
-	template <Quantization Q = q>
 	void GetPruningThreshold(uint32_t k,
 	                         std::priority_queue<KNNCandidate, std::vector<KNNCandidate>, VectorComparator> &heap,
-	                         DistanceType_t<Q> &pruning_threshold, uint32_t current_dimension_idx) {
+	                         distance_t &pruning_threshold, uint32_t current_dimension_idx) {
 		const std::lock_guard<std::mutex> lock(*best_k_mutex);
 		const float float_threshold = pruner.GetPruningThreshold(k, heap, current_dimension_idx);
-		if constexpr (Q == U8) {
+		if constexpr (q == U8) {
 			// We need to avoid undefined behaviour when overflow happens
 			const float scaled = float_threshold * pdx_data.quantization_scale_squared;
-			pruning_threshold = scaled >= static_cast<float>(std::numeric_limits<DistanceType_t<Q>>::max())
-			                        ? std::numeric_limits<DistanceType_t<Q>>::max()
-			                        : static_cast<DistanceType_t<Q>>(scaled);
+			pruning_threshold = scaled >= static_cast<float>(std::numeric_limits<distance_t>::max())
+			                        ? std::numeric_limits<distance_t>::max()
+			                        : static_cast<distance_t>(scaled);
 		} else {
 			pruning_threshold = float_threshold;
 		}
 	};
 
-	template <Quantization Q = q>
-	void EvaluatePruningPredicateScalar(uint32_t &n_pruned, size_t n_vectors, DistanceType_t<Q> *pruning_distances,
-	                                    const DistanceType_t<Q> pruning_threshold) {
+	void EvaluatePruningPredicateScalar(uint32_t &n_pruned, size_t n_vectors, distance_t *pruning_distances,
+	                                    const distance_t pruning_threshold) {
 		for (size_t vector_idx = 0; vector_idx < n_vectors; ++vector_idx) {
 			n_pruned += pruning_distances[vector_idx] >= pruning_threshold;
 		}
 	};
 
-	template <Quantization Q = q>
 	void EvaluatePruningPredicateOnPositionsArray(size_t n_vectors, size_t &n_vectors_not_pruned,
-	                                              uint32_t *pruning_positions, DistanceType_t<Q> pruning_threshold,
-	                                              DistanceType_t<Q> *pruning_distances) {
+	                                              uint32_t *pruning_positions, distance_t pruning_threshold,
+	                                              distance_t *pruning_distances) {
 		n_vectors_not_pruned = 0;
 		for (size_t vector_idx = 0; vector_idx < n_vectors; ++vector_idx) {
 			pruning_positions[n_vectors_not_pruned] = pruning_positions[vector_idx];
@@ -136,9 +132,9 @@ protected:
 		}
 	};
 
-	template <Quantization Q = q, bool IS_FILTERED = false>
+	template <bool IS_FILTERED = false>
 	void InitPositionsArray(size_t n_vectors, size_t &n_vectors_not_pruned, uint32_t *pruning_positions,
-	                        DistanceType_t<Q> pruning_threshold, DistanceType_t<Q> *pruning_distances,
+	                        distance_t pruning_threshold, distance_t *pruning_distances,
 	                        const uint8_t *selection_vector = nullptr) {
 		n_vectors_not_pruned = 0;
 		if constexpr (IS_FILTERED) {
@@ -155,7 +151,6 @@ protected:
 		}
 	};
 
-	template <Quantization Q = q>
 	void InitPositionsArrayFromSelectionVector(size_t n_vectors, size_t &n_vectors_not_pruned,
 	                                           uint32_t *pruning_positions, const uint8_t *selection_vector) {
 		n_vectors_not_pruned = 0;
@@ -165,18 +160,17 @@ protected:
 		}
 	};
 
-	template <Quantization Q = q>
-	void MaskDistancesWithSelectionVector(size_t n_vectors, DistanceType_t<Q> *pruning_distances,
+	void MaskDistancesWithSelectionVector(size_t n_vectors, distance_t *pruning_distances,
 	                                      const uint8_t *selection_vector) {
 		for (size_t vector_idx = 0; vector_idx < n_vectors; ++vector_idx) {
 			if (selection_vector[vector_idx] == 0) {
 				// Why max()/2? To prevent overflow if distances are still added to these
-				pruning_distances[vector_idx] = std::numeric_limits<DistanceType_t<Q>>::max() / 2;
+				pruning_distances[vector_idx] = std::numeric_limits<distance_t>::max() / 2;
 			}
 		}
 	};
 
-	static void GetClustersAccessOrderIVF(const float *__restrict query, const INDEX_TYPE &data, size_t nprobe,
+	static void GetClustersAccessOrderIVF(const float *__restrict query, const index_t &data, size_t nprobe,
 	                                      uint32_t *clusters_indices) {
 		std::unique_ptr<float[]> distances_to_centroids(new float[data.num_clusters]);
 		for (size_t cluster_idx = 0; cluster_idx < data.num_clusters; cluster_idx++) {
@@ -198,17 +192,17 @@ protected:
 	}
 
 	// On the warmup phase, we keep scanning dimensions until the amount of not-yet pruned vectors is low
-	template <Quantization Q = q, bool FILTERED = false>
-	void Warmup(const QuantizedEmbeddingType_t<Q> *__restrict query, const DataType_t<Q> *__restrict data,
+	template <bool FILTERED = false>
+	void Warmup(const quantized_embedding_t *__restrict query, const data_t *__restrict data,
 	            const size_t n_vectors, uint32_t k, float tuples_threshold, uint32_t *pruning_positions,
-	            DistanceType_t<Q> *pruning_distances, DistanceType_t<Q> &pruning_threshold,
+	            distance_t *pruning_distances, distance_t &pruning_threshold,
 	            std::priority_queue<KNNCandidate, std::vector<KNNCandidate>, VectorComparator> &heap,
 	            uint32_t &current_dimension_idx, size_t &n_vectors_not_pruned, uint32_t passing_tuples = 0,
 	            uint8_t *selection_vector = nullptr) {
 		current_dimension_idx = 0;
 		size_t cur_subgrouping_size_idx = 0;
 		size_t tuples_needed_to_exit = static_cast<size_t>(std::ceil(tuples_threshold * static_cast<float>(n_vectors)));
-		ResetPruningDistances<Q>(n_vectors, pruning_distances);
+		ResetPruningDistances(n_vectors, pruning_distances);
 		uint32_t n_tuples_to_prune = 0;
 		if constexpr (FILTERED) {
 			float selection_percentage = (static_cast<float>(passing_tuples) / static_cast<float>(n_vectors));
@@ -218,32 +212,32 @@ protected:
 				return;
 			}
 		}
-		GetPruningThreshold<Q>(k, heap, pruning_threshold, current_dimension_idx);
+		GetPruningThreshold(k, heap, pruning_threshold, current_dimension_idx);
 		while (n_tuples_to_prune < tuples_needed_to_exit && current_dimension_idx < pdx_data.num_vertical_dimensions) {
 			size_t last_dimension_to_fetch =
 			    std::min(current_dimension_idx + DIMENSIONS_FETCHING_SIZES[cur_subgrouping_size_idx],
 			             pdx_data.num_vertical_dimensions);
-			DistanceComputer<alpha, Q>::Vertical(query, data, n_vectors, n_vectors, current_dimension_idx,
+			distance_computer_t::Vertical(query, data, n_vectors, n_vectors, current_dimension_idx,
 			                                     last_dimension_to_fetch, pruning_distances, pruning_positions);
 			current_dimension_idx = last_dimension_to_fetch;
 			cur_subgrouping_size_idx += 1;
-			GetPruningThreshold<Q>(k, heap, pruning_threshold, current_dimension_idx);
+			GetPruningThreshold(k, heap, pruning_threshold, current_dimension_idx);
 			n_tuples_to_prune = 0;
-			EvaluatePruningPredicateScalar<Q>(n_tuples_to_prune, n_vectors, pruning_distances, pruning_threshold);
+			EvaluatePruningPredicateScalar(n_tuples_to_prune, n_vectors, pruning_distances, pruning_threshold);
 		}
 	}
 
 	// We scan only the not-yet pruned vectors
-	template <Quantization Q = q, bool FILTERED = false>
-	void Prune(const QuantizedEmbeddingType_t<Q> *__restrict query, const DataType_t<Q> *__restrict data,
-	           const size_t n_vectors, uint32_t k, uint32_t *pruning_positions, DistanceType_t<Q> *pruning_distances,
-	           DistanceType_t<Q> &pruning_threshold,
+	template <bool FILTERED = false>
+	void Prune(const quantized_embedding_t *__restrict query, const data_t *__restrict data,
+	           const size_t n_vectors, uint32_t k, uint32_t *pruning_positions, distance_t *pruning_distances,
+	           distance_t &pruning_threshold,
 	           std::priority_queue<KNNCandidate, std::vector<KNNCandidate>, VectorComparator> &heap,
 	           uint32_t &current_dimension_idx, size_t &n_vectors_not_pruned,
 	           const uint8_t *selection_vector = nullptr) {
-		GetPruningThreshold<Q>(k, heap, pruning_threshold, current_dimension_idx);
-		InitPositionsArray<Q, FILTERED>(n_vectors, n_vectors_not_pruned, pruning_positions, pruning_threshold,
-		                                pruning_distances, selection_vector);
+		GetPruningThreshold(k, heap, pruning_threshold, current_dimension_idx);
+		InitPositionsArray<FILTERED>(n_vectors, n_vectors_not_pruned, pruning_positions, pruning_threshold,
+		                             pruning_distances, selection_vector);
 		size_t cur_n_vectors_not_pruned = 0;
 		size_t current_vertical_dimension = current_dimension_idx;
 		size_t current_horizontal_dimension = 0;
@@ -262,22 +256,22 @@ protected:
 				size_t v_idx = pruning_positions[vector_idx];
 				size_t data_pos = offset_data + (v_idx * H_DIM_SIZE);
 				pruning_distances[v_idx] +=
-				    DistanceComputer<alpha, Q>::Horizontal(query + offset_query, data + data_pos, H_DIM_SIZE);
+				    distance_computer_t::Horizontal(query + offset_query, data + data_pos, H_DIM_SIZE);
 			}
 			// end of clipping
 			current_horizontal_dimension += H_DIM_SIZE;
 			current_dimension_idx += H_DIM_SIZE;
-			GetPruningThreshold<Q>(k, heap, pruning_threshold, current_dimension_idx);
+			GetPruningThreshold(k, heap, pruning_threshold, current_dimension_idx);
 			assert(current_dimension_idx == current_vertical_dimension + current_horizontal_dimension);
-			EvaluatePruningPredicateOnPositionsArray<Q>(cur_n_vectors_not_pruned, n_vectors_not_pruned,
-			                                            pruning_positions, pruning_threshold, pruning_distances);
+			EvaluatePruningPredicateOnPositionsArray(cur_n_vectors_not_pruned, n_vectors_not_pruned,
+			                                         pruning_positions, pruning_threshold, pruning_distances);
 		}
 		// GO THROUGH THE REST IN THE VERTICAL
 		while (n_vectors_not_pruned && current_vertical_dimension < pdx_data.num_vertical_dimensions) {
 			cur_n_vectors_not_pruned = n_vectors_not_pruned;
 			size_t last_dimension_to_test_idx = std::min(current_vertical_dimension + H_DIM_SIZE,
 			                                             static_cast<size_t>(pdx_data.num_vertical_dimensions));
-			DistanceComputer<alpha, Q>::VerticalPruning(query, data, cur_n_vectors_not_pruned, n_vectors,
+			distance_computer_t::VerticalPruning(query, data, cur_n_vectors_not_pruned, n_vectors,
 			                                            current_vertical_dimension, last_dimension_to_test_idx,
 			                                            pruning_distances, pruning_positions);
 			current_dimension_idx =
@@ -285,23 +279,22 @@ protected:
 			current_vertical_dimension = std::min(static_cast<uint32_t>(current_vertical_dimension + H_DIM_SIZE),
 			                                      pdx_data.num_vertical_dimensions);
 			assert(current_dimension_idx == current_vertical_dimension + current_horizontal_dimension);
-			GetPruningThreshold<Q>(k, heap, pruning_threshold, current_dimension_idx);
-			EvaluatePruningPredicateOnPositionsArray<Q>(cur_n_vectors_not_pruned, n_vectors_not_pruned,
-			                                            pruning_positions, pruning_threshold, pruning_distances);
+			GetPruningThreshold(k, heap, pruning_threshold, current_dimension_idx);
+			EvaluatePruningPredicateOnPositionsArray(cur_n_vectors_not_pruned, n_vectors_not_pruned,
+			                                         pruning_positions, pruning_threshold, pruning_distances);
 			if (current_dimension_idx == pdx_data.num_dimensions) {
 				break;
 			}
 		}
 	}
 
-	template <Quantization Q = q>
 	void MergeIntoHeap(const uint32_t *vector_indices, const size_t n_vectors, const uint32_t k,
-	                   const uint32_t *pruning_positions, const DistanceType_t<Q> *pruning_distances,
+	                   const uint32_t *pruning_positions, const distance_t *pruning_distances,
 	                   std::priority_queue<KNNCandidate, std::vector<KNNCandidate>, VectorComparator> &heap) {
 		for (size_t position_idx = 0; position_idx < n_vectors; ++position_idx) {
 			const size_t index = pruning_positions[position_idx];
 			float current_distance = static_cast<float>(pruning_distances[index]);
-			if constexpr (Q == U8) {
+			if constexpr (q == U8) {
 				current_distance *= pdx_data.inverse_quantization_scale_squared;
 			}
 			if (heap.size() < k || current_distance < heap.top().distance) {
@@ -349,17 +342,17 @@ public:
 		assert(k != 0);
 		assert(prepared_query);
 
-		std::unique_ptr<DISTANCES_TYPE[]> pruning_distances(new DISTANCES_TYPE[max_cluster_size]);
+		std::unique_ptr<distance_t[]> pruning_distances(new distance_t[max_cluster_size]);
 		std::unique_ptr<uint32_t[]> pruning_positions(new uint32_t[max_cluster_size]);
 
 		const size_t end_idx = std::min<size_t>(num_clusters_to_probe, pdx_data.num_clusters);
 		for (size_t cluster_idx = 0; cluster_idx < end_idx; ++cluster_idx) {
-			DISTANCES_TYPE pruning_threshold = std::numeric_limits<DISTANCES_TYPE>::max();
+			distance_t pruning_threshold = std::numeric_limits<distance_t>::max();
 			uint32_t current_dimension_idx = 0;
 			size_t n_vectors_not_pruned = 0;
 
 			const size_t current_cluster_idx = cluster_indices_in_access_order[cluster_idx];
-			const CLUSTER_TYPE &cluster = pdx_data.clusters[current_cluster_idx];
+			const cluster_t &cluster = pdx_data.clusters[current_cluster_idx];
 			if (cluster.num_embeddings == 0) {
 				continue;
 			}
@@ -385,13 +378,13 @@ public:
 		assert(predicate_evaluator);
 		assert(prepared_query);
 
-		std::unique_ptr<DISTANCES_TYPE[]> pruning_distances(new DISTANCES_TYPE[max_cluster_size]);
+		std::unique_ptr<distance_t[]> pruning_distances(new distance_t[max_cluster_size]);
 		std::unique_ptr<uint32_t[]> pruning_positions(new uint32_t[max_cluster_size]);
 
 		const size_t end_idx =
 		    std::min<size_t>(cluster_indices_in_access_order_offset + num_clusters_to_probe, pdx_data.num_clusters);
 		for (; cluster_indices_in_access_order_offset < end_idx; ++cluster_indices_in_access_order_offset) {
-			DISTANCES_TYPE pruning_threshold = std::numeric_limits<DISTANCES_TYPE>::max();
+			distance_t pruning_threshold = std::numeric_limits<distance_t>::max();
 			uint32_t current_dimension_idx = 0;
 			size_t n_vectors_not_pruned = 0;
 
@@ -401,15 +394,15 @@ public:
 			if (passing_tuples == 0) {
 				continue;
 			}
-			const CLUSTER_TYPE &cluster = pdx_data.clusters[current_cluster_idx];
+			const cluster_t &cluster = pdx_data.clusters[current_cluster_idx];
 			if (cluster.num_embeddings == 0) {
 				continue;
 			}
 
-			Warmup<q, true>(prepared_query, cluster.data, cluster.num_embeddings, k, selectivity_threshold,
+			Warmup<true>(prepared_query, cluster.data, cluster.num_embeddings, k, selectivity_threshold,
 			                pruning_positions.get(), pruning_distances.get(), pruning_threshold, *best_k,
 			                current_dimension_idx, n_vectors_not_pruned, passing_tuples, selection_vector);
-			Prune<q, true>(prepared_query, cluster.data, cluster.num_embeddings, k, pruning_positions.get(),
+			Prune<true>(prepared_query, cluster.data, cluster.num_embeddings, k, pruning_positions.get(),
 			               pruning_distances.get(), pruning_threshold, *best_k, current_dimension_idx,
 			               n_vectors_not_pruned, selection_vector);
 			if (n_vectors_not_pruned) {
@@ -426,20 +419,19 @@ public:
 	 ******************************************************************/
 
 	// On the first bucket, we do a full scan (we do not prune vectors)
-	template <Quantization Q = q>
-	void Start(const QuantizedEmbeddingType_t<Q> *__restrict query, const DataType_t<Q> *data, const size_t n_vectors,
+	void Start(const quantized_embedding_t *__restrict query, const data_t *data, const size_t n_vectors,
 	           uint32_t k, const uint32_t *vector_indices, uint32_t *pruning_positions,
-	           DistanceType_t<Q> *pruning_distances,
+	           distance_t *pruning_distances,
 	           std::priority_queue<KNNCandidate, std::vector<KNNCandidate>, VectorComparator> &heap) {
-		ResetPruningDistances<Q>(n_vectors, pruning_distances);
-		DistanceComputer<alpha, Q>::Vertical(query, data, n_vectors, n_vectors, 0, pdx_data.num_vertical_dimensions,
+		ResetPruningDistances(n_vectors, pruning_distances);
+		distance_computer_t::Vertical(query, data, n_vectors, n_vectors, 0, pdx_data.num_vertical_dimensions,
 		                                     pruning_distances, pruning_positions);
 		for (size_t horizontal_dimension = 0; horizontal_dimension < pdx_data.num_horizontal_dimensions;
 		     horizontal_dimension += H_DIM_SIZE) {
 			for (size_t vector_idx = 0; vector_idx < n_vectors; vector_idx++) {
 				size_t data_pos = (pdx_data.num_vertical_dimensions * n_vectors) + (horizontal_dimension * n_vectors) +
 				                  (vector_idx * H_DIM_SIZE);
-				pruning_distances[vector_idx] += DistanceComputer<alpha, Q>::Horizontal(
+				pruning_distances[vector_idx] += distance_computer_t::Horizontal(
 				    query + pdx_data.num_vertical_dimensions + horizontal_dimension, data + data_pos, H_DIM_SIZE);
 			}
 		}
@@ -457,7 +449,7 @@ public:
 			size_t index = indices_sorted[idx];
 			embedding.index = vector_indices[index];
 			embedding.distance = static_cast<float>(pruning_distances[index]);
-			if constexpr (Q == U8) {
+			if constexpr (q == U8) {
 				embedding.distance *= pdx_data.inverse_quantization_scale_squared;
 			}
 			heap.push(embedding);
@@ -465,16 +457,15 @@ public:
 	}
 
 	// On the first bucket, we do a full scan (we do not prune vectors)
-	template <Quantization Q = q>
-	void FilteredStart(const QuantizedEmbeddingType_t<Q> *__restrict query, const DataType_t<Q> *data,
+	void FilteredStart(const quantized_embedding_t *__restrict query, const data_t *data,
 	                   const size_t n_vectors, uint32_t k, const uint32_t *vector_indices, uint32_t *pruning_positions,
-	                   DistanceType_t<Q> *pruning_distances,
+	                   distance_t *pruning_distances,
 	                   std::priority_queue<KNNCandidate, std::vector<KNNCandidate>, VectorComparator> &heap,
 	                   uint8_t *selection_vector, uint32_t passing_tuples) {
-		ResetPruningDistances<Q>(n_vectors, pruning_distances);
+		ResetPruningDistances(n_vectors, pruning_distances);
 		size_t n_vectors_not_pruned = 0;
 		float selection_percentage = (static_cast<float>(passing_tuples) / static_cast<float>(n_vectors));
-		InitPositionsArrayFromSelectionVector<Q>(n_vectors, n_vectors_not_pruned, pruning_positions, selection_vector);
+		InitPositionsArrayFromSelectionVector(n_vectors, n_vectors_not_pruned, pruning_positions, selection_vector);
 		// Always start with horizontal block, regardless of selectivity
 		for (size_t horizontal_dimension = 0; horizontal_dimension < pdx_data.num_horizontal_dimensions;
 		     horizontal_dimension += H_DIM_SIZE) {
@@ -482,17 +473,17 @@ public:
 			for (size_t vector_idx = 0; vector_idx < n_vectors_not_pruned; vector_idx++) {
 				size_t v_idx = pruning_positions[vector_idx];
 				size_t data_pos = offset_data + (v_idx * H_DIM_SIZE);
-				pruning_distances[v_idx] += DistanceComputer<alpha, Q>::Horizontal(
+				pruning_distances[v_idx] += distance_computer_t::Horizontal(
 				    query + pdx_data.num_vertical_dimensions + horizontal_dimension, data + data_pos, H_DIM_SIZE);
 			}
 		}
 		if (selection_percentage > (1 - selectivity_threshold)) {
 			// It is then faster to do the full scan (thanks to SIMD)
-			DistanceComputer<alpha, Q>::Vertical(query, data, n_vectors, n_vectors, 0, pdx_data.num_vertical_dimensions,
+			distance_computer_t::Vertical(query, data, n_vectors, n_vectors, 0, pdx_data.num_vertical_dimensions,
 			                                     pruning_distances, pruning_positions);
 		} else {
 			// We access individual values
-			DistanceComputer<alpha, Q>::VerticalPruning(query, data, n_vectors_not_pruned, n_vectors, 0,
+			distance_computer_t::VerticalPruning(query, data, n_vectors_not_pruned, n_vectors, 0,
 			                                            pdx_data.num_vertical_dimensions, pruning_distances,
 			                                            pruning_positions);
 		}
@@ -511,14 +502,14 @@ public:
 			size_t index = indices_sorted[idx];
 			embedding.index = vector_indices[index];
 			embedding.distance = static_cast<float>(pruning_distances[index]);
-			if constexpr (Q == U8) {
+			if constexpr (q == U8) {
 				embedding.distance *= pdx_data.inverse_quantization_scale_squared;
 			}
 			heap.push(embedding);
 		}
 	}
 
-	std::vector<KNNCandidate_t> SearchGlobal(const float *__restrict const raw_query, const uint32_t k) {
+	std::vector<KNNCandidate> SearchGlobal(const float *__restrict const raw_query, const uint32_t k) {
 		Heap local_heap {};
 		std::mutex local_mutex;
 		best_k_mutex = &local_mutex;
@@ -537,9 +528,9 @@ public:
 		std::unique_ptr<uint32_t[]> local_cluster_order(new uint32_t[pdx_data.num_clusters]);
 		GetClustersAccessOrderIVF(query.get(), pdx_data, clusters_to_visit, local_cluster_order.get());
 		// PDXearch core
-		std::unique_ptr<QUANTIZED_EMBEDDING_TYPE[]> local_quantized_query(
-		    new QUANTIZED_EMBEDDING_TYPE[pdx_data.num_dimensions]);
-		QUANTIZED_EMBEDDING_TYPE *local_prepared_query;
+		std::unique_ptr<quantized_embedding_t[]> local_quantized_query(
+		    new quantized_embedding_t[pdx_data.num_dimensions]);
+		quantized_embedding_t *local_prepared_query;
 		if constexpr (q == U8) {
 			quantizer.QuantizeEmbedding(query.get(), pdx_data.quantization_base, pdx_data.quantization_scale,
 			                            local_quantized_query.get());
@@ -548,16 +539,16 @@ public:
 			local_prepared_query = query.get();
 		}
 
-		std::unique_ptr<DISTANCES_TYPE[]> pruning_distances(new DISTANCES_TYPE[max_cluster_size]);
+		std::unique_ptr<distance_t[]> pruning_distances(new distance_t[max_cluster_size]);
 		std::unique_ptr<uint32_t[]> pruning_positions(new uint32_t[max_cluster_size]);
 
 		for (size_t cluster_idx = 0; cluster_idx < clusters_to_visit; ++cluster_idx) {
-			DISTANCES_TYPE pruning_threshold = std::numeric_limits<DISTANCES_TYPE>::max();
+			distance_t pruning_threshold = std::numeric_limits<distance_t>::max();
 			uint32_t current_dimension_idx = 0;
 			size_t n_vectors_not_pruned = 0;
 
 			const size_t current_cluster_idx = local_cluster_order[cluster_idx];
-			CLUSTER_TYPE &cluster = pdx_data.clusters[current_cluster_idx];
+			cluster_t &cluster = pdx_data.clusters[current_cluster_idx];
 			if (cluster.num_embeddings == 0) {
 				continue;
 			}
@@ -580,7 +571,7 @@ public:
 		return BuildResultSetFromHeap(k, local_heap);
 	}
 
-	std::vector<KNNCandidate_t> FilteredSearchGlobal(const float *__restrict const raw_query, const uint32_t k,
+	std::vector<KNNCandidate> FilteredSearchGlobal(const float *__restrict const raw_query, const uint32_t k,
 	                                                 const PredicateEvaluator &predicate_evaluator) {
 		Heap local_heap {};
 		std::mutex local_mutex;
@@ -600,9 +591,9 @@ public:
 		std::unique_ptr<uint32_t[]> local_cluster_order(new uint32_t[pdx_data.num_clusters]);
 		GetClustersAccessOrderIVF(query.get(), pdx_data, clusters_to_visit, local_cluster_order.get());
 		// PDXearch core
-		std::unique_ptr<QUANTIZED_EMBEDDING_TYPE[]> local_quantized_query(
-		    new QUANTIZED_EMBEDDING_TYPE[pdx_data.num_dimensions]);
-		QUANTIZED_EMBEDDING_TYPE *local_prepared_query;
+		std::unique_ptr<quantized_embedding_t[]> local_quantized_query(
+		    new quantized_embedding_t[pdx_data.num_dimensions]);
+		quantized_embedding_t *local_prepared_query;
 		if constexpr (q == U8) {
 			quantizer.QuantizeEmbedding(query.get(), pdx_data.quantization_base, pdx_data.quantization_scale,
 			                            local_quantized_query.get());
@@ -611,11 +602,11 @@ public:
 			local_prepared_query = query.get();
 		}
 
-		std::unique_ptr<DISTANCES_TYPE[]> pruning_distances(new DISTANCES_TYPE[max_cluster_size]);
+		std::unique_ptr<distance_t[]> pruning_distances(new distance_t[max_cluster_size]);
 		std::unique_ptr<uint32_t[]> pruning_positions(new uint32_t[max_cluster_size]);
 
 		for (size_t cluster_idx = 0; cluster_idx < clusters_to_visit; ++cluster_idx) {
-			DISTANCES_TYPE pruning_threshold = std::numeric_limits<DISTANCES_TYPE>::max();
+			distance_t pruning_threshold = std::numeric_limits<distance_t>::max();
 			uint32_t current_dimension_idx = 0;
 			size_t n_vectors_not_pruned = 0;
 
@@ -625,7 +616,7 @@ public:
 			if (passing_tuples == 0) {
 				continue;
 			}
-			CLUSTER_TYPE &cluster = pdx_data.clusters[current_cluster_idx];
+			cluster_t &cluster = pdx_data.clusters[current_cluster_idx];
 			if (cluster.num_embeddings == 0) {
 				continue;
 			}
@@ -636,10 +627,10 @@ public:
 				              passing_tuples);
 				continue;
 			}
-			Warmup<q, true>(local_prepared_query, cluster.data, cluster.num_embeddings, k, selectivity_threshold,
+			Warmup<true>(local_prepared_query, cluster.data, cluster.num_embeddings, k, selectivity_threshold,
 			                pruning_positions.get(), pruning_distances.get(), pruning_threshold, local_heap,
 			                current_dimension_idx, n_vectors_not_pruned, passing_tuples, selection_vector);
-			Prune<q, true>(local_prepared_query, cluster.data, cluster.num_embeddings, k, pruning_positions.get(),
+			Prune<true>(local_prepared_query, cluster.data, cluster.num_embeddings, k, pruning_positions.get(),
 			               pruning_distances.get(), pruning_threshold, local_heap, current_dimension_idx,
 			               n_vectors_not_pruned, selection_vector);
 			if (n_vectors_not_pruned) {

--- a/src/include/pdxearch/pruners/adsampling.hpp
+++ b/src/include/pdxearch/pruners/adsampling.hpp
@@ -27,15 +27,12 @@ public:
 		}
 #ifdef HAS_FFTW
 		if (num_dimensions >= D_THRESHOLD_FOR_DCT_ROTATION) {
-			matrix = Eigen::Map<const matrix_t>(
-			    matrix_p, 1, num_dimensions);
+			matrix = Eigen::Map<const matrix_t>(matrix_p, 1, num_dimensions);
 		} else {
-			matrix = Eigen::Map<const matrix_t>(
-			    matrix_p, num_dimensions, num_dimensions);
+			matrix = Eigen::Map<const matrix_t>(matrix_p, num_dimensions, num_dimensions);
 		}
 #else
-		matrix = Eigen::Map<const matrix_t>(
-		    matrix_p, num_dimensions, num_dimensions);
+		matrix = Eigen::Map<const matrix_t>(matrix_p, num_dimensions, num_dimensions);
 #endif
 	}
 

--- a/src/include/pdxearch/pruners/adsampling.hpp
+++ b/src/include/pdxearch/pruners/adsampling.hpp
@@ -97,29 +97,12 @@ private:
 	            const size_t n) const {
 		const char trans_a = 'T';
 		const char trans_b = 'N';
-		int m = static_cast<int>(num_dimensions);
+		const float alpha = 1.0f;
+		const float beta = 0.0f;
+		int dim = static_cast<int>(num_dimensions);
 		int n_blas = static_cast<int>(n);
-		int k = static_cast<int>(num_dimensions);
-		float alpha = 1.0f;
-		float beta = 0.0f;
-		int lda = static_cast<int>(num_dimensions);
-		int ldb = static_cast<int>(num_dimensions);
-		int ldc = static_cast<int>(num_dimensions);
-		sgemm_(
-			&trans_a,
-			&trans_b,
-			&m,
-			&n_blas,
-			&k,
-			&alpha,
-			matrix.data(),
-			&lda,
-			embeddings,
-			&ldb,
-			&beta,
-			out_buffer,
-			&ldc
-		);
+		sgemm_(&trans_a, &trans_b, &dim, &n_blas, &dim, &alpha, matrix.data(), &dim, embeddings, &dim, &beta,
+		        out_buffer, &dim);
 	}
 };
 

--- a/src/include/pdxearch/pruners/adsampling.hpp
+++ b/src/include/pdxearch/pruners/adsampling.hpp
@@ -13,7 +13,7 @@ namespace PDX {
 /******************************************************************
  * ADSampling pruner
  ******************************************************************/
-template <Quantization q = F32>
+template <Quantization Q = F32>
 class ADSamplingPruner {
 
 public:
@@ -102,7 +102,7 @@ private:
 		int dim = static_cast<int>(num_dimensions);
 		int n_blas = static_cast<int>(n);
 		sgemm_(&trans_a, &trans_b, &dim, &n_blas, &dim, &alpha, matrix.data(), &dim, embeddings, &dim, &beta,
-		        out_buffer, &dim);
+		       out_buffer, &dim);
 	}
 };
 

--- a/src/include/pdxearch/pruners/adsampling.hpp
+++ b/src/include/pdxearch/pruners/adsampling.hpp
@@ -15,6 +15,7 @@ namespace PDX {
  ******************************************************************/
 template <Quantization Q = F32>
 class ADSamplingPruner {
+	using matrix_t = eigen_matrix_t;
 
 public:
 	const uint32_t num_dimensions;
@@ -26,14 +27,14 @@ public:
 		}
 #ifdef HAS_FFTW
 		if (num_dimensions >= D_THRESHOLD_FOR_DCT_ROTATION) {
-			matrix = Eigen::Map<const Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>(
+			matrix = Eigen::Map<const matrix_t>(
 			    matrix_p, 1, num_dimensions);
 		} else {
-			matrix = Eigen::Map<const Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>(
+			matrix = Eigen::Map<const matrix_t>(
 			    matrix_p, num_dimensions, num_dimensions);
 		}
 #else
-		matrix = Eigen::Map<const Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>(
+		matrix = Eigen::Map<const matrix_t>(
 		    matrix_p, num_dimensions, num_dimensions);
 #endif
 	}
@@ -68,7 +69,7 @@ public:
 
 private:
 	float pruning_aggressiveness = ADSAMPLING_PRUNING_AGGRESIVENESS;
-	Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> matrix;
+	matrix_t matrix;
 	std::vector<float> ratios;
 
 	float GetRatio(const size_t &visited_dimensions) const {

--- a/src/include/pdxearch/quantizers/scalar.hpp
+++ b/src/include/pdxearch/quantizers/scalar.hpp
@@ -42,7 +42,7 @@ public:
 template <Quantization q = U8>
 class ScalarQuantizer : public Quantizer {
 public:
-	using quantized_embedding_t = QuantizedEmbeddingType_t<q>;
+	using quantized_embedding_t = pdx_quantized_embedding_t<q>;
 
 	explicit ScalarQuantizer(size_t num_dimensions) : Quantizer(num_dimensions) {
 	}

--- a/src/include/pdxearch/quantizers/scalar.hpp
+++ b/src/include/pdxearch/quantizers/scalar.hpp
@@ -39,10 +39,10 @@ public:
 	const size_t num_dimensions;
 };
 
-template <Quantization q = U8>
+template <Quantization Q = U8>
 class ScalarQuantizer : public Quantizer {
 public:
-	using quantized_embedding_t = pdx_quantized_embedding_t<q>;
+	using quantized_embedding_t = pdx_quantized_embedding_t<Q>;
 
 	explicit ScalarQuantizer(size_t num_dimensions) : Quantizer(num_dimensions) {
 	}


### PR DESCRIPTION
- Using `sgemm` for rotation (should be much faster in AMD/Intel machines)
- Many code refactoring to improve legibility
    - Introducing convention for type aliases (`snake_case_t`)
    - Normalizing template parameter names (`q` --> `Q`)
    - Remove the unnecessary `Quantization Q = q` templated implementations in `pdxearch.hpp`. 
- More efficient PDXify with Eigen, both 8 and 32 bits.
    - SuperKMeans PDXification is slightly different. Ideally, I will put these PDXification methods in the core library in the near future (very near)