### PR TITLE
Add metadata table function, implement `GetInMemorySize`, and enrich `EXPLAIN` output

### DIFF
--- a/src/include/index/pdxearch_index.hpp
+++ b/src/include/index/pdxearch_index.hpp
@@ -11,6 +11,16 @@
 
 namespace duckdb {
 
+struct PDXearchIndexStats {
+	string metric;
+	string quantization;
+	int64_t num_dimensions;
+	int64_t n_probe;
+	int64_t seed;
+	bool is_normalized;
+	int64_t approximate_lower_bound_memory_usage_bytes;
+};
+
 class PDXearchIndex : public BoundIndex {
 public:
 	static constexpr const char *TYPE_NAME = "PDXEARCH";
@@ -86,6 +96,8 @@ public:
 
 	idx_t GetInMemorySize(IndexLock &state) override;
 
+	unique_ptr<PDXearchIndexStats> GetStats(const ClientContext &context) const;
+
 	/******************************************************************
 	 * Index persistence
 	 ******************************************************************/
@@ -136,9 +148,7 @@ public:
 		return static_cast<PDXearchWrapperGlobalF32 *>(pdxearch_wrapper.get())->GetNumClusters();
 	}
 
-	PDX::Quantization GetQuantization() const {
-		return pdxearch_wrapper->GetQuantization();
-	}
+	string GetQuantization() const;
 
 	idx_t GetNumDimensions() const {
 		return pdxearch_wrapper->GetNumDimensions();

--- a/src/include/index/pdxearch_index_utils.hpp
+++ b/src/include/index/pdxearch_index_utils.hpp
@@ -3,6 +3,7 @@
 #include <Eigen/Dense>
 #include <random>
 
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/storage/storage_info.hpp"
 #include "pdxearch/common.hpp"
 #include "pdxearch/index_base/pdx_ivf.hpp"
@@ -170,6 +171,25 @@ public:
 
 [[nodiscard]] inline constexpr bool DistanceMetricRequiresNormalization(const PDX::DistanceMetric distance_metric) {
 	return distance_metric == PDX::DistanceMetric::COSINE || distance_metric == PDX::DistanceMetric::IP;
+}
+
+[[nodiscard]] inline string ConvertBytesToHumanReadableString(const uint64_t bytes) {
+	constexpr uint64_t kB = 1000;
+	constexpr uint64_t MB = kB * 1000;
+	constexpr uint64_t GB = MB * 1000;
+	constexpr uint64_t TB = GB * 1000;
+
+	if (bytes >= TB) {
+		return StringUtil::Format("%.2f TB", static_cast<double>(bytes) / static_cast<double>(TB));
+	} else if (bytes >= GB) {
+		return StringUtil::Format("%.2f GB", static_cast<double>(bytes) / static_cast<double>(GB));
+	} else if (bytes >= MB) {
+		return StringUtil::Format("%.2f MB", static_cast<double>(bytes) / static_cast<double>(MB));
+	} else if (bytes >= kB) {
+		return StringUtil::Format("%.2f kB", static_cast<double>(bytes) / static_cast<double>(kB));
+	} else {
+		return StringUtil::Format("%llu bytes", bytes);
+	}
 }
 
 } // namespace duckdb

--- a/src/include/index/pdxearch_module.hpp
+++ b/src/include/index/pdxearch_module.hpp
@@ -15,6 +15,8 @@ public:
 		RegisterIndexScan(loader);
 
 		RegisterScanOptimizer(db);
+
+		RegisterIndexInfo(loader);
 	}
 
 private:
@@ -22,6 +24,8 @@ private:
 	static void RegisterIndexScan(ExtensionLoader &loader);
 
 	static void RegisterScanOptimizer(DatabaseInstance &db);
+
+	static void RegisterIndexInfo(ExtensionLoader &loader);
 };
 
 } // namespace duckdb

--- a/src/include/index/pdxearch_wrapper.hpp
+++ b/src/include/index/pdxearch_wrapper.hpp
@@ -86,6 +86,7 @@ public:
 		return rotation_matrix.get();
 	}
 
+	// An approximate lower bound of the index's size in memory.
 	virtual uint64_t GetInMemorySizeInBytes() const = 0;
 };
 

--- a/src/include/index/pdxearch_wrapper.hpp
+++ b/src/include/index/pdxearch_wrapper.hpp
@@ -64,10 +64,6 @@ public:
 		throw NotImplementedException("PDXearchWrapper::Delete() not implemented");
 	}
 
-	uint64_t GetInMemorySize() const {
-		throw NotImplementedException("PDXearchWrapper::GetInMemorySize() not implemented");
-	}
-
 	uint32_t GetNumDimensions() const {
 		return num_dimensions;
 	}
@@ -89,6 +85,8 @@ public:
 	float *GetRotationMatrix() const {
 		return rotation_matrix.get();
 	}
+
+	virtual uint64_t GetInMemorySizeInBytes() const = 0;
 };
 
 struct RowIdClusterMapping {
@@ -107,6 +105,14 @@ public:
 	std::unique_ptr<PDX::ADSamplingPruner<Q>> pruner;
 	// The searcher is reinitialized and reused across DuckDB queries.
 	std::unique_ptr<PDX::PDXearch<Q>> searcher;
+
+	// Returns the in-memory size of the persistent elements of the row group in bytes.
+	uint64_t GetInMemorySizeInBytes() const {
+		uint64_t in_memory_size_in_bytes = sizeof(*this);
+		in_memory_size_in_bytes += index->GetInMemorySizeInBytes();
+		in_memory_size_in_bytes += row_id_metadata.capacity() * sizeof(*row_id_metadata.data());
+		return in_memory_size_in_bytes;
+	}
 };
 
 // The PDXearchWrapper for the parallel implementation. The parallel implementation uses a separate index for each row
@@ -282,6 +288,14 @@ public:
 	idx_t GetNumRowGroups() const {
 		return row_groups.size();
 	}
+
+	uint64_t GetInMemorySizeInBytes() const override {
+		uint64_t in_memory_size_in_bytes = sizeof(*this);
+		for (const auto &row_group : row_groups) {
+			in_memory_size_in_bytes += row_group.GetInMemorySizeInBytes();
+		}
+		return in_memory_size_in_bytes;
+	}
 };
 
 using PDXearchWrapperF32 = PDXearchWrapperParallel<PDX::F32>;
@@ -434,6 +448,13 @@ public:
 
 	idx_t GetNumClusters() const {
 		return num_clusters;
+	}
+
+	uint64_t GetInMemorySizeInBytes() const override {
+		uint64_t in_memory_size_in_bytes = sizeof(*this);
+		in_memory_size_in_bytes += index->GetInMemorySizeInBytes();
+		in_memory_size_in_bytes += row_id_cluster_mapping.capacity() * sizeof(*row_id_cluster_mapping.data());
+		return in_memory_size_in_bytes;
 	}
 };
 

--- a/src/include/pdxearch/common.hpp
+++ b/src/include/pdxearch/common.hpp
@@ -113,7 +113,7 @@ struct Cluster {
 	using data_t = pdx_data_t<Q>;
 
 	Cluster(uint32_t num_embeddings, uint32_t num_dimensions)
-	    : num_embeddings(num_embeddings), indices(new uint32_t[num_embeddings]),
+	    : num_embeddings(num_embeddings), num_dimensions(num_dimensions), indices(new uint32_t[num_embeddings]),
 	      data(new data_t[static_cast<uint64_t>(num_embeddings) * num_dimensions]) {
 	}
 
@@ -123,8 +123,14 @@ struct Cluster {
 	}
 
 	uint32_t num_embeddings {};
+	const uint32_t num_dimensions {};
 	uint32_t *indices = nullptr;
 	data_t *data = nullptr;
+
+	uint64_t GetInMemorySizeInBytes() const {
+		return sizeof(*this) + num_embeddings * sizeof(*indices) +
+		       num_embeddings * static_cast<uint64_t>(num_dimensions) * sizeof(*data);
+	}
 };
 
 using Heap = std::priority_queue<KNNCandidate, std::vector<KNNCandidate>, VectorComparator>;

--- a/src/include/pdxearch/index_base/pdx_ivf.hpp
+++ b/src/include/pdxearch/index_base/pdx_ivf.hpp
@@ -32,6 +32,17 @@ public:
 	      is_normalized(is_normalized) {
 		clusters.reserve(num_clusters);
 	}
+
+	uint64_t GetInMemorySizeInBytes() const {
+		uint64_t in_memory_size_in_bytes = 0;
+		in_memory_size_in_bytes += sizeof(*this);
+		for (const auto &cluster : clusters) {
+			in_memory_size_in_bytes += cluster.GetInMemorySizeInBytes();
+		}
+		in_memory_size_in_bytes += (clusters.capacity() - clusters.size()) * sizeof(*clusters.data());
+		in_memory_size_in_bytes += centroids.capacity() * sizeof(*centroids.data());
+		return in_memory_size_in_bytes;
+	}
 };
 
 template <>
@@ -63,6 +74,17 @@ public:
 	      inverse_quantization_scale_squared(1.0f / (quantization_scale * quantization_scale)),
 	      quantization_base(quantization_base) {
 		clusters.reserve(num_clusters);
+	}
+
+	uint64_t GetInMemorySizeInBytes() const {
+		uint64_t in_memory_size_in_bytes = 0;
+		in_memory_size_in_bytes += sizeof(*this);
+		for (const auto &cluster : clusters) {
+			in_memory_size_in_bytes += cluster.GetInMemorySizeInBytes();
+		}
+		in_memory_size_in_bytes += (clusters.capacity() - clusters.size()) * sizeof(*clusters.data());
+		in_memory_size_in_bytes += centroids.capacity() * sizeof(*centroids.data());
+		return in_memory_size_in_bytes;
 	}
 };
 

--- a/src/index/CMakeLists.txt
+++ b/src/index/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(EXTENSION_SOURCES
     ${EXTENSION_SOURCES}
     ${CMAKE_CURRENT_SOURCE_DIR}/pdxearch_index.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/pdxearch_index_info_function.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/create/pdxearch_index_create_plan.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/create/pdxearch_index_create.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/create/pdxearch_index_global_create.cpp

--- a/src/index/pdxearch_index.cpp
+++ b/src/index/pdxearch_index.cpp
@@ -241,7 +241,7 @@ void PDXearchIndex::VerifyAllocations(IndexLock &state) {
 }
 
 idx_t PDXearchIndex::GetInMemorySize(IndexLock &state) {
-	return 0;
+	return pdxearch_wrapper->GetInMemorySizeInBytes();
 }
 
 /******************************************************************

--- a/src/index/pdxearch_index_info_function.cpp
+++ b/src/index/pdxearch_index_info_function.cpp
@@ -1,0 +1,158 @@
+#include "duckdb/catalog/catalog_entry/index_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/storage/data_table.hpp"
+#include "duckdb/transaction/duck_transaction.hpp"
+#include "duckdb/transaction/local_storage.hpp"
+#include "duckdb/catalog/catalog_entry/duck_index_entry.hpp"
+
+#include "index/pdxearch_index.hpp"
+#include "index/pdxearch_module.hpp"
+
+namespace duckdb {
+
+struct IndexInfoColumnInput {
+	const IndexCatalogEntry &index_entry;
+	const TableCatalogEntry &table_entry;
+	const PDXearchIndexStats &stats;
+};
+
+struct IndexInfoColumn {
+	const char *name;
+	LogicalType type;
+	std::function<Value(const IndexInfoColumnInput &)> get_value;
+};
+
+// Defines the columns included in `CALL pdxearch_index_info();`.
+// Make sure to sync any changes made here to `PDXearchIndex::GetStats`.
+static const IndexInfoColumn INDEX_INFO_COLUMNS[] = {
+    {"catalog_name", LogicalType::VARCHAR,
+     [](const IndexInfoColumnInput &input) {
+	     return Value(input.index_entry.catalog.GetName());
+     }},
+    {"schema_name", LogicalType::VARCHAR,
+     [](const IndexInfoColumnInput &input) {
+	     return Value(input.index_entry.schema.name);
+     }},
+    {"index_name", LogicalType::VARCHAR,
+     [](const IndexInfoColumnInput &input) {
+	     return Value(input.index_entry.name);
+     }},
+    {"table_name", LogicalType::VARCHAR,
+     [](const IndexInfoColumnInput &input) {
+	     return Value(input.table_entry.name);
+     }},
+    {"metric", LogicalType::VARCHAR,
+     [](const IndexInfoColumnInput &input) {
+	     return Value(input.stats.metric);
+     }},
+    {"num_dimensions", LogicalType::BIGINT,
+     [](const IndexInfoColumnInput &input) {
+	     return Value::BIGINT(input.stats.num_dimensions);
+     }},
+    {"quantization", LogicalType::VARCHAR,
+     [](const IndexInfoColumnInput &input) {
+	     return Value(input.stats.quantization);
+     }},
+    {"n_probe", LogicalType::BIGINT,
+     [](const IndexInfoColumnInput &input) {
+	     return Value::BIGINT(input.stats.n_probe);
+     }},
+    {"seed", LogicalType::BIGINT,
+     [](const IndexInfoColumnInput &input) {
+	     return Value::BIGINT(input.stats.seed);
+     }},
+    {"is_normalized", LogicalType::BOOLEAN,
+     [](const IndexInfoColumnInput &input) {
+	     return Value::BOOLEAN(input.stats.is_normalized);
+     }},
+    {"approx_lower_bound_memory_usage_bytes", LogicalType::BIGINT,
+     [](const IndexInfoColumnInput &input) {
+	     return Value::BIGINT(input.stats.approximate_lower_bound_memory_usage_bytes);
+     }},
+};
+
+static unique_ptr<FunctionData> PDXearchIndexInfoBind(ClientContext &context, TableFunctionBindInput &input,
+                                                      vector<LogicalType> &return_types, vector<string> &names) {
+	for (const auto &col : INDEX_INFO_COLUMNS) {
+		names.emplace_back(col.name);
+		return_types.push_back(col.type);
+	}
+	return nullptr;
+}
+
+struct PDXearchIndexInfoGlobalState : public GlobalTableFunctionState {
+	idx_t offset = 0;
+	vector<reference<IndexCatalogEntry>> entries;
+};
+
+static unique_ptr<GlobalTableFunctionState> PDXearchIndexInfoInitGlobal(ClientContext &context,
+                                                                        TableFunctionInitInput &input) {
+	auto result = make_uniq<PDXearchIndexInfoGlobalState>();
+
+	// scan all the schemas for indexes and collect them
+	auto schemas = Catalog::GetAllSchemas(context);
+	for (auto &schema : schemas) {
+		schema.get().Scan(context, CatalogType::INDEX_ENTRY, [&](CatalogEntry &entry) {
+			auto &index_entry = entry.Cast<IndexCatalogEntry>();
+			if (index_entry.index_type == PDXearchIndex::TYPE_NAME) {
+				result->entries.push_back(index_entry);
+			}
+		});
+	};
+	return std::move(result);
+}
+
+static void PDXearchIndexInfoExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<PDXearchIndexInfoGlobalState>();
+	if (data.offset >= data.entries.size()) {
+		return;
+	}
+
+	idx_t row = 0;
+	while (data.offset < data.entries.size() && row < STANDARD_VECTOR_SIZE) {
+		auto &index_entry = data.entries[data.offset++].get();
+		auto &table_entry = index_entry.schema.catalog.GetEntry<TableCatalogEntry>(context, index_entry.GetSchemaName(),
+		                                                                           index_entry.GetTableName());
+		auto &storage = table_entry.GetStorage();
+		PDXearchIndex *pdxearch_index = nullptr;
+
+		auto &table_info = *storage.GetDataTableInfo();
+
+		table_info.BindIndexes(context, PDXearchIndex::TYPE_NAME);
+		table_info.GetIndexes().Scan([&](Index &index) {
+			if (!index.IsBound() || PDXearchIndex::TYPE_NAME != index.GetIndexType()) {
+				return false;
+			}
+			auto &cast_index = index.Cast<PDXearchIndex>();
+			if (cast_index.name == index_entry.name) {
+				pdxearch_index = &cast_index;
+				return true;
+			}
+			return false;
+		});
+
+		if (!pdxearch_index) {
+			throw BinderException("Index %s not found", index_entry.name);
+		}
+
+		auto stats = pdxearch_index->GetStats(context);
+		IndexInfoColumnInput col_input {index_entry, table_entry, *stats};
+
+		for (idx_t col = 0; col < sizeof(INDEX_INFO_COLUMNS) / sizeof(INDEX_INFO_COLUMNS[0]); col++) {
+			output.data[col].SetValue(row, INDEX_INFO_COLUMNS[col].get_value(col_input));
+		}
+
+		row++;
+	}
+	output.SetCardinality(row);
+}
+
+void PDXearchModule::RegisterIndexInfo(ExtensionLoader &loader) {
+	TableFunction info_function("pdxearch_index_info", {}, PDXearchIndexInfoExecute, PDXearchIndexInfoBind,
+	                            PDXearchIndexInfoInitGlobal);
+	loader.RegisterFunction(info_function);
+}
+
+} // namespace duckdb

--- a/src/index/search/pdxearch_index_filtered_scan_physical.cpp
+++ b/src/index/search/pdxearch_index_filtered_scan_physical.cpp
@@ -385,13 +385,14 @@ SourceResultType PhysicalPDXearchIndexFilteredScan::GetData(ExecutionContext &co
 
 // Defines this operator's details shown in the query plan.
 InsertionOrderPreservingMap<string> PhysicalPDXearchIndexFilteredScan::ParamsToString() const {
+	auto &index = bind_data->index.Cast<PDXearchIndex>();
 	InsertionOrderPreservingMap<string> result;
 	result["Table"] = bind_data->table.name;
 	result["PDXearch Index"] = bind_data->index.GetIndexName();
-	result["Total Clusters"] =
-	    StringUtil::Format("%zu", bind_data->index.Cast<PDXearchIndex>().GetNumClustersPerRowGroup() *
-	                                  bind_data->index.Cast<PDXearchIndex>().GetNumRowGroups());
-	result["Row Groups"] = StringUtil::Format("%zu", bind_data->index.Cast<PDXearchIndex>().GetNumRowGroups());
+	result["Total Clusters"] = StringUtil::Format("%zu", index.GetNumClustersPerRowGroup() * index.GetNumRowGroups());
+	result["Row Groups"] = StringUtil::Format("%zu", index.GetNumRowGroups());
+	const idx_t index_in_memory_size = bind_data->index.Cast<BoundIndex>().GetInMemorySize();
+	result["Index Size"] = ConvertBytesToHumanReadableString(index_in_memory_size);
 	SetEstimatedCardinality(result, estimated_cardinality);
 
 	return result;

--- a/src/index/search/pdxearch_index_global_filtered_scan_physical.cpp
+++ b/src/index/search/pdxearch_index_global_filtered_scan_physical.cpp
@@ -187,6 +187,8 @@ InsertionOrderPreservingMap<string> PhysicalGlobalPDXearchIndexFilteredScan::Par
 	result["PDXearch Index"] = bind_data->index.GetIndexName();
 	result["Normalized"] = bind_data->index.Cast<PDXearchIndex>().IsNormalized() ? "true" : "false";
 	result["Clusters"] = StringUtil::Format("%zu", bind_data->index.Cast<PDXearchIndex>().GetNumClusters());
+	const idx_t index_in_memory_size = bind_data->index.Cast<BoundIndex>().GetInMemorySize();
+	result["Index Size"] = ConvertBytesToHumanReadableString(index_in_memory_size);
 	SetEstimatedCardinality(result, estimated_cardinality);
 
 	return result;

--- a/src/index/search/pdxearch_index_global_scan.cpp
+++ b/src/index/search/pdxearch_index_global_scan.cpp
@@ -89,6 +89,8 @@ static InsertionOrderPreservingMap<string> PDXearchIndexScanToString(TableFuncti
 	result["Table"] = bind_data.table.name;
 	result["PDXearch Index"] = bind_data.index.GetIndexName();
 	result["Clusters"] = StringUtil::Format("%zu", pdxearch_index.GetNumClusters());
+	const idx_t index_in_memory_size = bind_data.index.Cast<BoundIndex>().GetInMemorySize();
+	result["Index Size"] = ConvertBytesToHumanReadableString(index_in_memory_size);
 
 	return result;
 }

--- a/src/index/search/pdxearch_index_scan_physical.cpp
+++ b/src/index/search/pdxearch_index_scan_physical.cpp
@@ -226,6 +226,8 @@ InsertionOrderPreservingMap<string> PhysicalPDXearchIndexScan::ParamsToString() 
 	    StringUtil::Format("%zu", bind_data->index.Cast<PDXearchIndex>().GetNumClustersPerRowGroup() *
 	                                  bind_data->index.Cast<PDXearchIndex>().GetNumRowGroups());
 	result["Row Groups"] = StringUtil::Format("%zu", bind_data->index.Cast<PDXearchIndex>().GetNumRowGroups());
+	const idx_t index_in_memory_size = bind_data->index.Cast<BoundIndex>().GetInMemorySize();
+	result["Index Size"] = ConvertBytesToHumanReadableString(index_in_memory_size);
 	SetEstimatedCardinality(result, estimated_cardinality);
 
 	return result;


### PR DESCRIPTION
## Improvements

1. Add index metadata table function (`CALL pdxearch_index_info();`).
2. Implement `GetInMemorySize`.
3. Update custom operators' `EXPLAIN` node to include the new index size in human readable form.

## Examples
1. Execute `CALL pdxearch_index_info();` to show something like the following.

```
┌──────────────┬─────────────┬────────────┬────────────┬─────────┬───┬──────────────┬─────────┬────────────┬───────────────┬──────────────────────┐
│ catalog_name │ schema_name │ index_name │ table_name │ metric  │ … │ quantization │ n_probe │    seed    │ is_normalized │ approx_lower_bound…  │
│   varchar    │   varchar   │  varchar   │  varchar   │ varchar │   │   varchar    │  int64  │   int64    │    boolean    │        int64         │
├──────────────┼─────────────┼────────────┼────────────┼─────────┼───┼──────────────┼─────────┼────────────┼───────────────┼──────────────────────┤
│ debug        │ main        │ idx        │ t1         │ l2sq    │ … │ u8           │   24    │ 1603119593 │ false         │        988403        │
├──────────────┴─────────────┴────────────┴────────────┴─────────┴───┴──────────────┴─────────┴────────────┴───────────────┴──────────────────────┤
│ 1 rows                                                                                                                    11 columns (10 shown) │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

3. Below shows an example of the `EXPLAIN` node (the size is an example):

```
┌─────────────┴─────────────┐
│    PDXEARCH_INDEX_SCAN    │
│    ────────────────────   │
│        Table: table       │
│    PDXearch Index: idx    │
│       Clusters: 4000      │
│     Index Size: 1.97 GB   │
│                           │
│        Projections:       │
│             id            │
│            vec            │
│                           │
│      ~1,000,000 rows      │
└───────────────────────────┘
```