### PR TITLE
build: bump to DuckDB v1.5.1

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -14,10 +14,10 @@ concurrency:
 jobs:
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.4.4
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.0
     with:
-      duckdb_version: v1.4.4
-      ci_tools_version: v1.4.4
+      duckdb_version: v1.5.0
+      ci_tools_version: v1.5.0
       extension_name: pdxearch
       extra_toolchains: "fortran;omp"
       # Temporarily disabled to focus efforts on macOS and linux stability.
@@ -27,7 +27,7 @@ jobs:
     name: Code Quality Check
     uses: noorts/extension-ci-tools/.github/workflows/_extension_code_quality.yml@fix-tidy-check-vcpkg
     with:
-      duckdb_version: v1.4.4
+      duckdb_version: v1.5.0
       ci_tools_version: fix-tidy-check-vcpkg
       override_ci_tools_repository: noorts/extension-ci-tools
       extension_name: pdxearch

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -14,10 +14,10 @@ concurrency:
 jobs:
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.0
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.1
     with:
-      duckdb_version: v1.5.0
-      ci_tools_version: v1.5.0
+      duckdb_version: v1.5.1
+      ci_tools_version: v1.5.1
       extension_name: pdxearch
       extra_toolchains: "fortran;omp"
       # Temporarily disabled to focus efforts on macOS and linux stability.
@@ -27,7 +27,7 @@ jobs:
     name: Code Quality Check
     uses: noorts/extension-ci-tools/.github/workflows/_extension_code_quality.yml@fix-tidy-check-vcpkg
     with:
-      duckdb_version: v1.5.0
+      duckdb_version: v1.5.1
       ci_tools_version: fix-tidy-check-vcpkg
       override_ci_tools_repository: noorts/extension-ci-tools
       extension_name: pdxearch

--- a/src/include/index/create/pdxearch_index_create.hpp
+++ b/src/include/index/create/pdxearch_index_create.hpp
@@ -30,7 +30,8 @@ public:
 
 public:
 	//! Source interface, NOOP for this operator
-	SourceResultType GetData(ExecutionContext &context, DataChunk &chunk, OperatorSourceInput &input) const override {
+	SourceResultType GetDataInternal(ExecutionContext &context, DataChunk &chunk,
+	                                 OperatorSourceInput &input) const override {
 		return SourceResultType::FINISHED;
 	}
 	bool IsSource() const override {

--- a/src/include/index/create/pdxearch_index_global_create.hpp
+++ b/src/include/index/create/pdxearch_index_global_create.hpp
@@ -30,7 +30,8 @@ public:
 
 public:
 	//! Source interface, NOOP for this operator
-	SourceResultType GetData(ExecutionContext &context, DataChunk &chunk, OperatorSourceInput &input) const override {
+	SourceResultType GetDataInternal(ExecutionContext &context, DataChunk &chunk,
+	                                 OperatorSourceInput &input) const override {
 		return SourceResultType::FINISHED;
 	}
 	bool IsSource() const override {

--- a/src/include/index/pdxearch_index.hpp
+++ b/src/include/index/pdxearch_index.hpp
@@ -90,7 +90,9 @@ public:
 
 	void Vacuum(IndexLock &state) override;
 
-	string VerifyAndToString(IndexLock &state, const bool only_verify) override;
+	void Verify(IndexLock &state) override;
+
+	string ToString(IndexLock &state, bool display_ascii) override;
 
 	void VerifyAllocations(IndexLock &state) override;
 

--- a/src/include/index/pdxearch_module.hpp
+++ b/src/include/index/pdxearch_module.hpp
@@ -8,7 +8,6 @@ namespace duckdb {
 struct PDXearchModule {
 public:
 	static void Register(ExtensionLoader &loader) {
-
 		auto &db = loader.GetDatabaseInstance();
 
 		RegisterIndex(db);

--- a/src/include/index/search/pdxearch_index_filtered_scan_physical.hpp
+++ b/src/include/index/search/pdxearch_index_filtered_scan_physical.hpp
@@ -55,7 +55,8 @@ public:
 	unique_ptr<GlobalSourceState> GetGlobalSourceState(ClientContext &context) const override;
 	unique_ptr<LocalSourceState> GetLocalSourceState(ExecutionContext &context,
 	                                                 GlobalSourceState &gstate) const override;
-	SourceResultType GetData(ExecutionContext &context, DataChunk &chunk, OperatorSourceInput &input) const override;
+	SourceResultType GetDataInternal(ExecutionContext &context, DataChunk &chunk,
+	                                 OperatorSourceInput &input) const override;
 	bool IsSource() const override {
 		return true;
 	}

--- a/src/include/index/search/pdxearch_index_global_filtered_scan_physical.hpp
+++ b/src/include/index/search/pdxearch_index_global_filtered_scan_physical.hpp
@@ -55,7 +55,8 @@ public:
 	unique_ptr<GlobalSourceState> GetGlobalSourceState(ClientContext &context) const override;
 	unique_ptr<LocalSourceState> GetLocalSourceState(ExecutionContext &context,
 	                                                 GlobalSourceState &g_source) const override;
-	SourceResultType GetData(ExecutionContext &context, DataChunk &chunk, OperatorSourceInput &input) const override;
+	SourceResultType GetDataInternal(ExecutionContext &context, DataChunk &chunk,
+	                                 OperatorSourceInput &input) const override;
 	bool IsSource() const override {
 		return true;
 	}

--- a/src/include/index/search/pdxearch_index_scan_physical.hpp
+++ b/src/include/index/search/pdxearch_index_scan_physical.hpp
@@ -40,7 +40,8 @@ public:
 	unique_ptr<GlobalSourceState> GetGlobalSourceState(ClientContext &context) const override;
 	unique_ptr<LocalSourceState> GetLocalSourceState(ExecutionContext &context,
 	                                                 GlobalSourceState &g_source) const override;
-	SourceResultType GetData(ExecutionContext &context, DataChunk &chunk, OperatorSourceInput &input) const override;
+	SourceResultType GetDataInternal(ExecutionContext &context, DataChunk &chunk,
+	                                 OperatorSourceInput &input) const override;
 	bool IsSource() const override {
 		return true;
 	}

--- a/src/include/pdxearch/db_mock/predicate_evaluator.hpp
+++ b/src/include/pdxearch/db_mock/predicate_evaluator.hpp
@@ -7,7 +7,6 @@
 namespace PDX {
 
 class PredicateEvaluator {
-
 public:
 	// Number of tuples per cluster that passed the predicate.
 	std::unique_ptr<uint32_t[]> n_passing_tuples;

--- a/src/include/pdxearch/quantizers/scalar.hpp
+++ b/src/include/pdxearch/quantizers/scalar.hpp
@@ -14,7 +14,6 @@ struct ScalarQuantizationParams {
 };
 
 class Quantizer {
-
 public:
 	explicit Quantizer(size_t num_dimensions) : num_dimensions(num_dimensions) {
 	}

--- a/src/index/create/pdxearch_index_create.cpp
+++ b/src/index/create/pdxearch_index_create.cpp
@@ -18,7 +18,6 @@ PhysicalCreatePDXearchIndex::PhysicalCreatePDXearchIndex(PhysicalPlan &physical_
     : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, types_p, estimated_cardinality),
       table(table_p.Cast<DuckTableEntry>()), info(std::move(info)), unbound_expressions(std::move(unbound_expressions)),
       sorted(false) {
-
 	for (auto &virtual_column_id : column_ids) {
 		storage_ids.push_back(table.GetColumns().LogicalToPhysical(LogicalIndex(virtual_column_id)).index);
 	}

--- a/src/index/create/pdxearch_index_global_create.cpp
+++ b/src/index/create/pdxearch_index_global_create.cpp
@@ -16,7 +16,6 @@ PhysicalCreateGlobalPDXearchIndex::PhysicalCreateGlobalPDXearchIndex(
     : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, types_p, estimated_cardinality),
       table(table_p.Cast<DuckTableEntry>()), info(std::move(info)), unbound_expressions(std::move(unbound_expressions)),
       sorted(false) {
-
 	for (auto &virtual_column_id : column_ids) {
 		storage_ids.push_back(table.GetColumns().LogicalToPhysical(LogicalIndex(virtual_column_id)).index);
 	}

--- a/src/index/pdxearch_index.cpp
+++ b/src/index/pdxearch_index.cpp
@@ -14,7 +14,6 @@ PDXearchIndex::PDXearchIndex(const string &name, IndexConstraintType index_const
                              const case_insensitive_map_t<Value> &index_creation_options,
                              const IndexStorageInfo &persistence_info, idx_t estimated_cardinality)
     : BoundIndex(name, TYPE_NAME, index_constraint_type, column_ids, table_io_manager, unbound_expressions, db) {
-
 	if (index_constraint_type != IndexConstraintType::NONE) {
 		throw NotImplementedException("PDXearch indexes do not support unique or primary key constraints");
 	}
@@ -312,7 +311,6 @@ bool PDXearchIndex::TryMatchDistanceFunction(const unique_ptr<Expression> &expr,
 
 static void TryBindIndexExpressionInternal(Expression &expr, idx_t table_idx, const vector<column_t> &index_columns,
                                            const vector<ColumnIndex> &table_columns, bool &success, bool &found) {
-
 	if (expr.type == ExpressionType::BOUND_COLUMN_REF) {
 		found = true;
 		auto &ref = expr.Cast<BoundColumnRefExpression>();
@@ -424,7 +422,6 @@ unique_ptr<ExpressionMatcher> PDXearchIndex::MakeFunctionMatcher(const PDXearchW
 }
 
 void PDXearchModule::RegisterIndex(DatabaseInstance &db) {
-
 	IndexType index_type;
 
 	index_type.name = PDXearchIndex::TYPE_NAME;

--- a/src/index/pdxearch_index.cpp
+++ b/src/index/pdxearch_index.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "pdxearch/common.hpp"
 #include "index/pdxearch_index.hpp"
 

--- a/src/index/pdxearch_index.cpp
+++ b/src/index/pdxearch_index.cpp
@@ -232,8 +232,12 @@ bool PDXearchIndex::MergeIndexes(IndexLock &state, BoundIndex &other_index) {
 void PDXearchIndex::Vacuum(IndexLock &state) {
 }
 
-string PDXearchIndex::VerifyAndToString(IndexLock &state, const bool only_verify) {
-	throw NotImplementedException("PDXearchIndex::VerifyAndToString() not implemented");
+void PDXearchIndex::Verify(IndexLock &state) {
+	throw NotImplementedException("PDXearchIndex::Verify() not implemented");
+}
+
+string PDXearchIndex::ToString(IndexLock &state, bool display_ascii) {
+	throw NotImplementedException("PDXearchIndex::ToString() not implemented");
 }
 
 void PDXearchIndex::VerifyAllocations(IndexLock &state) {

--- a/src/index/pdxearch_index_info_function.cpp
+++ b/src/index/pdxearch_index_info_function.cpp
@@ -121,17 +121,17 @@ static void PDXearchIndexInfoExecute(ClientContext &context, TableFunctionInput 
 		auto &table_info = *storage.GetDataTableInfo();
 
 		table_info.BindIndexes(context, PDXearchIndex::TYPE_NAME);
-		table_info.GetIndexes().Scan([&](Index &index) {
+		for (auto &index : table_info.GetIndexes().Indexes()) {
 			if (!index.IsBound() || PDXearchIndex::TYPE_NAME != index.GetIndexType()) {
-				return false;
+				continue;
 			}
 			auto &cast_index = index.Cast<PDXearchIndex>();
 			if (cast_index.name == index_entry.name) {
 				pdxearch_index = &cast_index;
-				return true;
+				break;
 			}
-			return false;
-		});
+			continue;
+		};
 
 		if (!pdxearch_index) {
 			throw BinderException("Index %s not found", index_entry.name);

--- a/src/index/search/pdxearch_index_filtered_scan_physical.cpp
+++ b/src/index/search/pdxearch_index_filtered_scan_physical.cpp
@@ -29,7 +29,6 @@ public:
 	                                    const PDXearchIndexPhysicalScanBindData &bind_data)
 	    : context(context), op(op), limit(bind_data.limit), index(bind_data.index.Cast<PDXearchIndex>()),
 	      preprocessed_query_embedding(make_uniq_array<float>(index.GetNumDimensions())), pdxearch_row_ids(nullptr) {
-
 		// Preprocess the query embedding.
 		EmbeddingPreprocessor embedding_preprocessor(index.GetNumDimensions(), index.GetRotationMatrix());
 		embedding_preprocessor.PreprocessEmbedding(bind_data.query_embedding.get(), preprocessed_query_embedding.get(),

--- a/src/index/search/pdxearch_index_filtered_scan_physical.cpp
+++ b/src/index/search/pdxearch_index_filtered_scan_physical.cpp
@@ -352,8 +352,8 @@ unique_ptr<LocalSourceState> PhysicalPDXearchIndexFilteredScan::GetLocalSourceSt
 	return make_uniq<PhysicalFilteredScanLocalSourceState>();
 }
 
-SourceResultType PhysicalPDXearchIndexFilteredScan::GetData(ExecutionContext &context, DataChunk &output_chunk,
-                                                            OperatorSourceInput &input) const {
+SourceResultType PhysicalPDXearchIndexFilteredScan::GetDataInternal(ExecutionContext &context, DataChunk &output_chunk,
+                                                                    OperatorSourceInput &input) const {
 	auto &g_sink = sink_state->Cast<PhysicalFilteredScanGlobalSinkState>();
 	auto &g_source = input.global_state.Cast<PhysicalFilteredScanGlobalSourceState>();
 

--- a/src/index/search/pdxearch_index_global_filtered_scan_physical.cpp
+++ b/src/index/search/pdxearch_index_global_filtered_scan_physical.cpp
@@ -149,8 +149,9 @@ PhysicalGlobalPDXearchIndexFilteredScan::GetLocalSourceState(ExecutionContext &c
 	return make_uniq<PhysicalGlobalFilteredScanLocalSourceState>();
 }
 
-SourceResultType PhysicalGlobalPDXearchIndexFilteredScan::GetData(ExecutionContext &context, DataChunk &output_chunk,
-                                                                  OperatorSourceInput &input) const {
+SourceResultType PhysicalGlobalPDXearchIndexFilteredScan::GetDataInternal(ExecutionContext &context,
+                                                                          DataChunk &output_chunk,
+                                                                          OperatorSourceInput &input) const {
 	auto &g_sink = sink_state->Cast<PhysicalGlobalFilteredScanGlobalSinkState>();
 	auto &g_source = input.global_state.Cast<PhysicalGlobalFilteredScanGlobalSourceState>();
 

--- a/src/index/search/pdxearch_index_global_scan.cpp
+++ b/src/index/search/pdxearch_index_global_scan.cpp
@@ -57,7 +57,6 @@ static unique_ptr<GlobalTableFunctionState> PDXearchIndexScanInitGlobal(ClientCo
 }
 
 static void PDXearchIndexScanExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
-
 	auto &bind_data = data_p.bind_data->Cast<PDXearchIndexScanBindData>();
 	auto &state = data_p.global_state->Cast<PDXearchIndexScanGlobalState>();
 	auto &transaction = DuckTransaction::Get(context, bind_data.table.catalog);

--- a/src/index/search/pdxearch_index_scan_physical.cpp
+++ b/src/index/search/pdxearch_index_scan_physical.cpp
@@ -26,7 +26,6 @@ public:
 	    : context(context), op(op), limit(bind_data.limit), index(bind_data.index.Cast<PDXearchIndex>()),
 	      preprocessed_query_embedding(make_uniq_array<float>(index.GetNumDimensions())), search_started(false),
 	      search_completed(false), pdxearch_row_ids(nullptr), pdxearch_row_ids_idx(0) {
-
 		// Preprocess the query embedding.
 		const EmbeddingPreprocessor embedding_preprocessor =
 		    EmbeddingPreprocessor(index.GetNumDimensions(), index.GetRotationMatrix());

--- a/src/index/search/pdxearch_index_scan_physical.cpp
+++ b/src/index/search/pdxearch_index_scan_physical.cpp
@@ -171,8 +171,8 @@ unique_ptr<LocalSourceState> PhysicalPDXearchIndexScan::GetLocalSourceState(Exec
 	return make_uniq<PDXearchScanLocalSourceState>();
 }
 
-SourceResultType PhysicalPDXearchIndexScan::GetData(ExecutionContext &context, DataChunk &output_chunk,
-                                                    OperatorSourceInput &input) const {
+SourceResultType PhysicalPDXearchIndexScan::GetDataInternal(ExecutionContext &context, DataChunk &output_chunk,
+                                                            OperatorSourceInput &input) const {
 	auto &g_state = input.global_state.Cast<PDXearchScanGlobalSourceState>();
 
 	// Trigger parallel search of all row groups.

--- a/src/index/search/pdxearch_scan_optimizer.cpp
+++ b/src/index/search/pdxearch_scan_optimizer.cpp
@@ -451,7 +451,6 @@ public:
 	}
 
 	static bool OptimizeChildren(ClientContext &context, unique_ptr<LogicalOperator> &plan) {
-
 		auto ok = TryOptimize(context, plan);
 		// Recursively optimize the children
 		for (auto &child : plan->children) {
@@ -471,7 +470,6 @@ public:
 				    // Filtered search
 				    (child->children[0]->type == LogicalOperatorType::LOGICAL_EXTENSION_OPERATOR &&
 				     child->children[0]->GetName() == "PDXEARCH_INDEX_FILT_SCAN")) {
-
 					auto &parent_projection = plan->Cast<LogicalProjection>();
 					auto &child_projection = child->Cast<LogicalProjection>();
 
@@ -515,7 +513,7 @@ public:
 
 void PDXearchModule::RegisterScanOptimizer(DatabaseInstance &db) {
 	// Register the optimizer extension
-	db.config.optimizer_extensions.push_back(PDXearchIndexScanOptimizer());
+	OptimizerExtension::Register(db.config, PDXearchIndexScanOptimizer());
 }
 
 } // namespace duckdb

--- a/src/index/search/pdxearch_scan_optimizer.cpp
+++ b/src/index/search/pdxearch_scan_optimizer.cpp
@@ -289,9 +289,9 @@ public:
 		vector<reference<Expression>> bindings;
 
 		table_info.BindIndexes(context, PDXearchIndex::TYPE_NAME);
-		table_info.GetIndexes().Scan([&](Index &index) {
+		for (auto &index : table_info.GetIndexes().Indexes()) {
 			if (!index.IsBound() || PDXearchIndex::TYPE_NAME != index.GetIndexType()) {
-				return false;
+				continue;
 			}
 			auto &cast_index = index.Cast<PDXearchIndex>();
 
@@ -300,12 +300,12 @@ public:
 
 			// Check that the projection expression is a distance function that matches the index
 			if (!cast_index.TryMatchDistanceFunction(projection_expr, bindings)) {
-				return false;
+				continue;
 			}
 			// Check that the PDXearch index actually indexes the expression
 			unique_ptr<Expression> index_expr;
 			if (!cast_index.TryBindIndexExpression(get, index_expr)) {
-				return false;
+				continue;
 			}
 
 			// Now, ensure that one of the bindings is a constant vector, and the other our index expression
@@ -318,7 +318,7 @@ public:
 				if (const_expr_ref.get().type != ExpressionType::VALUE_CONSTANT ||
 				    !index_expr->Equals(index_expr_ref)) {
 					// Nope, not a match, we can't optimize.
-					return false;
+					continue;
 				}
 			}
 
@@ -344,8 +344,8 @@ public:
 
 			bind_data =
 			    make_uniq<PDXearchIndexScanBindData>(duck_table, cast_index, top_n.limit, std::move(query_embedding));
-			return true;
-		});
+			break;
+		}
 
 		if (!bind_data) {
 			// No index found


### PR DESCRIPTION
Submodule and CI bumps, as well as compatibility changes for the new v1.5.1 API.

We'll refactor to use the new index build abstraction at a later date.
- https://github.com/duckdb/duckdb/pull/19461
- https://github.com/duckdb/duckdb/pull/20158