### PR TITLE
Encode Float Vector Constant into a BLOB containing homebrew FP16s

### DIFF
--- a/src/include/index/pdxearch_blob_codec.hpp
+++ b/src/include/index/pdxearch_blob_codec.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "duckdb/common/types.hpp"
+
+#include <cmath>
+#include <cstdint>
+
+namespace duckdb {
+
+// Lossy int16 quantization for float vectors.
+//
+// Encoding: each float -> int16_t
+//   Lower 2 bits = X (scale selector, 0..3)
+//   Upper 14 bits = quantized value (signed, [-8192, 8191])
+//   Decode: float = (int16 >> 2) * BLOB_SCALE[int16 & 3]
+//   Encode: pick smallest X where round(float * inv_scale[X]) fits in 14-bit signed range
+//
+// Blob size = N * 2 bytes (no header).
+
+constexpr float BLOB_SCALE[4] = {0.00001f, 0.0001f, 0.001f, 0.01f};
+constexpr float BLOB_INV_SCALE[4] = {100000.0f, 10000.0f, 1000.0f, 100.0f};
+
+inline int16_t EncodeFloatToInt16(float value) {
+	for (int x = 0; x < 4; x++) {
+		auto q = static_cast<int32_t>(std::round(value * BLOB_INV_SCALE[x]));
+		if (q >= -8192 && q <= 8191) {
+			return static_cast<int16_t>((q << 2) | x);
+		}
+	}
+	// Clamp to max range at largest scale
+	auto q = static_cast<int32_t>(std::round(value * BLOB_INV_SCALE[3]));
+	if (q > 8191) {
+		q = 8191;
+	} else if (q < -8192) {
+		q = -8192;
+	}
+	return static_cast<int16_t>((q << 2) | 3);
+}
+
+inline float DecodeInt16ToFloat(int16_t encoded) {
+	int x = encoded & 3;
+	int32_t q = encoded >> 2; // arithmetic right shift
+	return static_cast<float>(q) * BLOB_SCALE[x];
+}
+
+inline void EncodeFloatArrayToBlob(const float *input, idx_t count, data_ptr_t output) {
+	auto *out = reinterpret_cast<int16_t *>(output);
+	for (idx_t i = 0; i < count; i++) {
+		out[i] = EncodeFloatToInt16(input[i]);
+	}
+}
+
+inline void DecodeBlobToFloatArray(const_data_ptr_t input, idx_t blob_size, float *output) {
+	idx_t count = blob_size / 2;
+	auto *in = reinterpret_cast<const int16_t *>(input);
+	for (idx_t i = 0; i < count; i++) {
+		output[i] = DecodeInt16ToFloat(in[i]);
+	}
+}
+
+inline idx_t BlobDimensionCount(idx_t blob_byte_size) {
+	return blob_byte_size / 2;
+}
+
+} // namespace duckdb

--- a/src/include/index/pdxearch_blob_functions.hpp
+++ b/src/include/index/pdxearch_blob_functions.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+struct PDXearchBlobFunctions {
+	static void Register(ExtensionLoader &loader);
+};
+
+} // namespace duckdb

--- a/src/include/index/pdxearch_module.hpp
+++ b/src/include/index/pdxearch_module.hpp
@@ -17,6 +17,7 @@ public:
 		RegisterScanOptimizer(db);
 
 		RegisterIndexInfo(loader);
+		RegisterBlobFunctions(loader);
 	}
 
 private:
@@ -26,6 +27,7 @@ private:
 	static void RegisterScanOptimizer(DatabaseInstance &db);
 
 	static void RegisterIndexInfo(ExtensionLoader &loader);
+	static void RegisterBlobFunctions(ExtensionLoader &loader);
 };
 
 } // namespace duckdb

--- a/src/index/CMakeLists.txt
+++ b/src/index/CMakeLists.txt
@@ -12,4 +12,5 @@ set(EXTENSION_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/search/pdxearch_index_scan_logical.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/search/pdxearch_index_scan_physical.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/search/pdxearch_scan_optimizer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/pdxearch_blob_functions.cpp
     PARENT_SCOPE)

--- a/src/index/pdxearch_blob_functions.cpp
+++ b/src/index/pdxearch_blob_functions.cpp
@@ -1,0 +1,333 @@
+#include "index/pdxearch_blob_functions.hpp"
+#include "index/pdxearch_blob_codec.hpp"
+#include "index/pdxearch_module.hpp"
+
+#include "duckdb/common/types/blob.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/vector_operations/unary_executor.hpp"
+#include "duckdb/common/vector_operations/binary_executor.hpp"
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+
+#include <cmath>
+
+namespace duckdb {
+
+//------------------------------------------------------------------------------
+// Distance Kernels (mirroring core_functions/array_kernels.hpp)
+//------------------------------------------------------------------------------
+
+struct BlobDistanceOp {
+	template <class TYPE>
+	static TYPE Operation(const TYPE *lhs, const TYPE *rhs, idx_t count) {
+		TYPE dist = 0;
+		for (idx_t i = 0; i < count; i++) {
+			auto diff = lhs[i] - rhs[i];
+			dist += diff * diff;
+		}
+		return std::sqrt(dist);
+	}
+};
+
+struct BlobCosineDistanceOp {
+	template <class TYPE>
+	static TYPE Operation(const TYPE *lhs, const TYPE *rhs, idx_t count) {
+		TYPE dot = 0, norm_l = 0, norm_r = 0;
+		for (idx_t i = 0; i < count; i++) {
+			dot += lhs[i] * rhs[i];
+			norm_l += lhs[i] * lhs[i];
+			norm_r += rhs[i] * rhs[i];
+		}
+		auto similarity = dot / std::sqrt(norm_l * norm_r);
+		similarity = std::max(static_cast<TYPE>(-1.0), std::min(similarity, static_cast<TYPE>(1.0)));
+		return static_cast<TYPE>(1.0) - similarity;
+	}
+};
+
+//------------------------------------------------------------------------------
+// Utility Functions
+//------------------------------------------------------------------------------
+
+static void EncodeBlobFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto count = args.size();
+	auto &input = args.data[0];
+
+	UnifiedVectorFormat input_format;
+	input.ToUnifiedFormat(count, input_format);
+
+	auto &child_vec = ListVector::GetEntry(input);
+	auto child_data = FlatVector::GetData<float>(child_vec);
+	auto list_entries = UnifiedVectorFormat::GetData<list_entry_t>(input_format);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = input_format.sel->get_index(i);
+		if (!input_format.validity.RowIsValid(idx)) {
+			FlatVector::SetNull(result, i, true);
+			continue;
+		}
+		auto &entry = list_entries[idx];
+		auto blob_size = entry.length * sizeof(int16_t);
+		auto blob = StringVector::EmptyString(result, blob_size);
+		EncodeFloatArrayToBlob(child_data + entry.offset, entry.length, data_ptr_cast(blob.GetDataWriteable()));
+		blob.Finalize();
+		FlatVector::GetData<string_t>(result)[i] = blob;
+	}
+
+	if (count == 1) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+}
+
+static void DecodeBlobFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto count = args.size();
+	auto &input = args.data[0];
+
+	UnifiedVectorFormat input_format;
+	input.ToUnifiedFormat(count, input_format);
+
+	auto input_data = UnifiedVectorFormat::GetData<string_t>(input_format);
+
+	auto &child_vec = ListVector::GetEntry(result);
+	idx_t total_elements = 0;
+
+	// First pass: count total elements
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = input_format.sel->get_index(i);
+		if (input_format.validity.RowIsValid(idx)) {
+			total_elements += BlobDimensionCount(input_data[idx].GetSize());
+		}
+	}
+
+	ListVector::Reserve(result, total_elements);
+	auto child_data = FlatVector::GetData<float>(child_vec);
+	auto list_entries = FlatVector::GetData<list_entry_t>(result);
+
+	idx_t offset = 0;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = input_format.sel->get_index(i);
+		if (!input_format.validity.RowIsValid(idx)) {
+			FlatVector::SetNull(result, i, true);
+			continue;
+		}
+		auto &blob = input_data[idx];
+		auto dim_count = BlobDimensionCount(blob.GetSize());
+		list_entries[i].offset = offset;
+		list_entries[i].length = dim_count;
+		DecodeBlobToFloatArray(const_data_ptr_cast(blob.GetData()), blob.GetSize(), child_data + offset);
+		offset += dim_count;
+	}
+	ListVector::SetListSize(result, offset);
+
+	if (count == 1) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+}
+
+static void BlobToBase64Function(DataChunk &args, ExpressionState &state, Vector &result) {
+	UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](string_t blob) {
+		auto base64_size = Blob::ToBase64Size(blob);
+		auto base64 = StringVector::EmptyString(result, base64_size);
+		Blob::ToBase64(blob, base64.GetDataWriteable());
+		base64.Finalize();
+		return base64;
+	});
+}
+
+static void Base64ToBlobFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](string_t str) {
+		auto blob_size = Blob::FromBase64Size(str);
+		auto blob = StringVector::EmptyString(result, blob_size);
+		Blob::FromBase64(str, data_ptr_cast(blob.GetDataWriteable()), blob_size);
+		blob.Finalize();
+		return blob;
+	});
+}
+
+//------------------------------------------------------------------------------
+// Distance Function Overloads (BLOB, ARRAY)
+//------------------------------------------------------------------------------
+
+struct BlobDistanceBindData : public FunctionData {
+	idx_t array_size;
+
+	explicit BlobDistanceBindData(idx_t array_size) : array_size(array_size) {
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<BlobDistanceBindData>(array_size);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<BlobDistanceBindData>();
+		return array_size == other.array_size;
+	}
+};
+
+// Bind for (BLOB, ARRAY) - blob is arg 0, array is arg 1
+static unique_ptr<FunctionData> BlobArrayDistanceBind(ClientContext &context, ScalarFunction &bound_function,
+                                                      vector<unique_ptr<Expression>> &arguments) {
+	auto &array_type = arguments[1]->return_type;
+	if (array_type.id() != LogicalTypeId::ARRAY) {
+		throw BinderException("%s: second argument must be an ARRAY type", bound_function.name);
+	}
+	auto array_size = ArrayType::GetSize(array_type);
+	bound_function.arguments[1] = LogicalType::ARRAY(LogicalType::FLOAT, array_size);
+	return make_uniq<BlobDistanceBindData>(array_size);
+}
+
+// Bind for (ARRAY, BLOB) - array is arg 0, blob is arg 1
+static unique_ptr<FunctionData> ArrayBlobDistanceBind(ClientContext &context, ScalarFunction &bound_function,
+                                                      vector<unique_ptr<Expression>> &arguments) {
+	auto &array_type = arguments[0]->return_type;
+	if (array_type.id() != LogicalTypeId::ARRAY) {
+		throw BinderException("%s: first argument must be an ARRAY type", bound_function.name);
+	}
+	auto array_size = ArrayType::GetSize(array_type);
+	bound_function.arguments[0] = LogicalType::ARRAY(LogicalType::FLOAT, array_size);
+	return make_uniq<BlobDistanceBindData>(array_size);
+}
+
+// Execute: (BLOB, ARRAY<FLOAT>[N]) → FLOAT
+template <class OP>
+static void BlobArrayDistanceExecute(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_state = state.Cast<ExecuteFunctionState>();
+	auto &bind_data = func_state.expr.Cast<BoundFunctionExpression>().bind_info->Cast<BlobDistanceBindData>();
+	auto array_size = bind_data.array_size;
+
+	auto count = args.size();
+	auto &blob_vec = args.data[0];
+	auto &array_vec = args.data[1];
+
+	UnifiedVectorFormat blob_format;
+	blob_vec.ToUnifiedFormat(count, blob_format);
+	auto blob_data = UnifiedVectorFormat::GetData<string_t>(blob_format);
+
+	UnifiedVectorFormat array_format;
+	array_vec.ToUnifiedFormat(count, array_format);
+
+	auto &array_child = ArrayVector::GetEntry(array_vec);
+	auto array_child_data = FlatVector::GetData<float>(array_child);
+
+	auto res_data = FlatVector::GetData<float>(result);
+
+	auto decoded = make_unsafe_uniq_array<float>(array_size);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto blob_idx = blob_format.sel->get_index(i);
+		auto array_idx = array_format.sel->get_index(i);
+
+		if (!blob_format.validity.RowIsValid(blob_idx) || !array_format.validity.RowIsValid(array_idx)) {
+			FlatVector::SetNull(result, i, true);
+			continue;
+		}
+
+		auto &blob = blob_data[blob_idx];
+		if (BlobDimensionCount(blob.GetSize()) != array_size) {
+			throw InvalidInputException("BLOB dimension count (%llu) does not match array size (%llu)",
+			                            BlobDimensionCount(blob.GetSize()), array_size);
+		}
+
+		DecodeBlobToFloatArray(const_data_ptr_cast(blob.GetData()), blob.GetSize(), decoded.get());
+		res_data[i] =
+		    OP::template Operation<float>(decoded.get(), array_child_data + array_idx * array_size, array_size);
+	}
+
+	if (count == 1) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+}
+
+// Execute: (ARRAY<FLOAT>[N], BLOB) → FLOAT
+template <class OP>
+static void ArrayBlobDistanceExecute(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_state = state.Cast<ExecuteFunctionState>();
+	auto &bind_data = func_state.expr.Cast<BoundFunctionExpression>().bind_info->Cast<BlobDistanceBindData>();
+	auto array_size = bind_data.array_size;
+
+	auto count = args.size();
+	auto &array_vec = args.data[0];
+	auto &blob_vec = args.data[1];
+
+	UnifiedVectorFormat array_format;
+	array_vec.ToUnifiedFormat(count, array_format);
+	auto &array_child = ArrayVector::GetEntry(array_vec);
+	auto array_child_data = FlatVector::GetData<float>(array_child);
+
+	UnifiedVectorFormat blob_format;
+	blob_vec.ToUnifiedFormat(count, blob_format);
+	auto blob_data = UnifiedVectorFormat::GetData<string_t>(blob_format);
+
+	auto res_data = FlatVector::GetData<float>(result);
+
+	auto decoded = make_unsafe_uniq_array<float>(array_size);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto array_idx = array_format.sel->get_index(i);
+		auto blob_idx = blob_format.sel->get_index(i);
+
+		if (!array_format.validity.RowIsValid(array_idx) || !blob_format.validity.RowIsValid(blob_idx)) {
+			FlatVector::SetNull(result, i, true);
+			continue;
+		}
+
+		auto &blob = blob_data[blob_idx];
+		if (BlobDimensionCount(blob.GetSize()) != array_size) {
+			throw InvalidInputException("BLOB dimension count (%llu) does not match array size (%llu)",
+			                            BlobDimensionCount(blob.GetSize()), array_size);
+		}
+
+		DecodeBlobToFloatArray(const_data_ptr_cast(blob.GetData()), blob.GetSize(), decoded.get());
+		res_data[i] =
+		    OP::template Operation<float>(array_child_data + array_idx * array_size, decoded.get(), array_size);
+	}
+
+	if (count == 1) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+}
+
+template <class OP>
+static void RegisterDistanceOverloads(ExtensionLoader &loader, const string &func_name) {
+	auto array_type = LogicalType::ARRAY(LogicalType::FLOAT, optional_idx());
+
+	// (BLOB, ARRAY<FLOAT>[N]) → FLOAT
+	ScalarFunction blob_array(func_name, {LogicalType::BLOB, array_type}, LogicalType::FLOAT,
+	                          BlobArrayDistanceExecute<OP>, BlobArrayDistanceBind);
+	loader.AddFunctionOverload(blob_array);
+
+	// (ARRAY<FLOAT>[N], BLOB) → FLOAT
+	ScalarFunction array_blob(func_name, {array_type, LogicalType::BLOB}, LogicalType::FLOAT,
+	                          ArrayBlobDistanceExecute<OP>, ArrayBlobDistanceBind);
+	loader.AddFunctionOverload(array_blob);
+}
+
+//------------------------------------------------------------------------------
+// Registration
+//------------------------------------------------------------------------------
+
+void PDXearchBlobFunctions::Register(ExtensionLoader &loader) {
+	// Utility functions
+	loader.RegisterFunction(ScalarFunction("pdxearch_encode_blob", {LogicalType::LIST(LogicalType::FLOAT)},
+	                                       LogicalType::BLOB, EncodeBlobFunction));
+
+	loader.RegisterFunction(ScalarFunction("pdxearch_decode_blob", {LogicalType::BLOB},
+	                                       LogicalType::LIST(LogicalType::FLOAT), DecodeBlobFunction));
+
+	loader.RegisterFunction(
+	    ScalarFunction("pdxearch_blob_to_base64", {LogicalType::BLOB}, LogicalType::VARCHAR, BlobToBase64Function));
+
+	loader.RegisterFunction(
+	    ScalarFunction("pdxearch_base64_to_blob", {LogicalType::VARCHAR}, LogicalType::BLOB, Base64ToBlobFunction));
+
+	// Distance function overloads
+	RegisterDistanceOverloads<BlobDistanceOp>(loader, "array_distance");
+	RegisterDistanceOverloads<BlobDistanceOp>(loader, "<->");
+	RegisterDistanceOverloads<BlobCosineDistanceOp>(loader, "array_cosine_distance");
+	RegisterDistanceOverloads<BlobCosineDistanceOp>(loader, "<=>");
+}
+
+void PDXearchModule::RegisterBlobFunctions(ExtensionLoader &loader) {
+	PDXearchBlobFunctions::Register(loader);
+}
+
+} // namespace duckdb

--- a/src/index/pdxearch_index.cpp
+++ b/src/index/pdxearch_index.cpp
@@ -405,14 +405,14 @@ unique_ptr<ExpressionMatcher> PDXearchIndex::MakeFunctionMatcher(const PDXearchW
 	matcher->expr_type = make_uniq<SpecificExpressionTypeMatcher>(ExpressionType::BOUND_FUNCTION);
 	matcher->policy = SetMatcher::Policy::UNORDERED;
 
+	auto array_type = LogicalType::ARRAY(LogicalType::FLOAT, pdxearch_wrapper.GetNumDimensions());
+
 	auto lhs_matcher = make_uniq<ExpressionMatcher>();
-	lhs_matcher->type =
-	    make_uniq<SpecificTypeMatcher>(LogicalType::ARRAY(LogicalType::FLOAT, pdxearch_wrapper.GetNumDimensions()));
+	lhs_matcher->type = make_uniq<SetTypesMatcher>(vector<LogicalType>({array_type, LogicalType::BLOB}));
 	matcher->matchers.push_back(std::move(lhs_matcher));
 
 	auto rhs_matcher = make_uniq<ExpressionMatcher>();
-	rhs_matcher->type =
-	    make_uniq<SpecificTypeMatcher>(LogicalType::ARRAY(LogicalType::FLOAT, pdxearch_wrapper.GetNumDimensions()));
+	rhs_matcher->type = make_uniq<SetTypesMatcher>(vector<LogicalType>({array_type, LogicalType::BLOB}));
 	matcher->matchers.push_back(std::move(rhs_matcher));
 
 	return std::move(matcher);

--- a/src/index/search/pdxearch_scan_optimizer.cpp
+++ b/src/index/search/pdxearch_scan_optimizer.cpp
@@ -8,6 +8,8 @@
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/planner/operator/logical_top_n.hpp"
 #include "duckdb/storage/data_table.hpp"
+
+#include "index/pdxearch_blob_codec.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 
 #include "index/pdxearch_module.hpp"
@@ -323,9 +325,21 @@ public:
 			const auto num_dimensions = cast_index.GetNumDimensions();
 			const auto &matched_embedding = const_expr_ref.get().Cast<BoundConstantExpression>().value;
 			auto query_embedding = make_unsafe_uniq_array<float>(num_dimensions);
-			auto embedding_elements = ArrayValue::GetChildren(matched_embedding);
-			for (idx_t i = 0; i < num_dimensions; i++) {
-				query_embedding[i] = embedding_elements[i].GetValue<float>();
+
+			if (matched_embedding.type().id() == LogicalTypeId::BLOB) {
+				// BLOB path: decode the quantized blob to float array
+				auto blob = StringValue::Get(matched_embedding);
+				auto blob_dims = BlobDimensionCount(blob.size());
+				if (blob_dims != num_dimensions) {
+					return false;
+				}
+				DecodeBlobToFloatArray(const_data_ptr_cast(blob.data()), blob.size(), query_embedding.get());
+			} else {
+				// ARRAY path: existing logic
+				auto embedding_elements = ArrayValue::GetChildren(matched_embedding);
+				for (idx_t i = 0; i < num_dimensions; i++) {
+					query_embedding[i] = embedding_elements[i].GetValue<float>();
+				}
 			}
 
 			bind_data =

--- a/test/sql/search/index_scan_blob_query.test
+++ b/test/sql/search/index_scan_blob_query.test
@@ -110,7 +110,7 @@ CREATE INDEX t2_idx ON t2 USING PDXEARCH (emb) WITH (metric = '${metric_name}');
 
 # Index scan is used with blob query
 query II
-EXPLAIN SELECT * FROM t2 ORDER BY ${distance_func}(emb, pdxearch_encode_blob(${QUERY_EMB}::FLOAT[${DIMS}]::FLOAT[])) LIMIT 10;
+EXPLAIN SELECT * FROM t2 ORDER BY ${distance_func}(emb, pdxearch_encode_blob(${QUERY_EMB}::FLOAT[])) LIMIT 10;
 ----
 physical_plan	<REGEX>:.*PDXEARCH_INDEX_SCAN.*
 
@@ -127,7 +127,7 @@ statement ok
 CREATE INDEX t2_idx ON t2 USING PDXEARCH (emb) WITH (metric = 'l2sq');
 
 query II
-EXPLAIN SELECT * FROM t2 ORDER BY emb <-> pdxearch_encode_blob(${QUERY_EMB}::FLOAT[${DIMS}]::FLOAT[]) LIMIT 10;
+EXPLAIN SELECT * FROM t2 ORDER BY emb <-> pdxearch_encode_blob(${QUERY_EMB}::FLOAT[]) LIMIT 10;
 ----
 physical_plan	<REGEX>:.*PDXEARCH_INDEX_SCAN.*
 
@@ -138,7 +138,7 @@ statement ok
 CREATE INDEX t2_idx ON t2 USING PDXEARCH (emb) WITH (metric = 'cosine');
 
 query II
-EXPLAIN SELECT * FROM t2 ORDER BY emb <=> pdxearch_encode_blob(${QUERY_EMB}::FLOAT[${DIMS}]::FLOAT[]) LIMIT 10;
+EXPLAIN SELECT * FROM t2 ORDER BY emb <=> pdxearch_encode_blob(${QUERY_EMB}::FLOAT[]) LIMIT 10;
 ----
 physical_plan	<REGEX>:.*PDXEARCH_INDEX_SCAN.*
 

--- a/test/sql/search/index_scan_blob_query.test
+++ b/test/sql/search/index_scan_blob_query.test
@@ -1,0 +1,146 @@
+# name: test/sql/search/index_scan_blob_query.test
+# description: Test blob-based query vectors for PDXearch index scan
+# group: [search]
+
+require parquet
+
+require pdxearch
+
+# ============================================
+# 1. Encode/decode round-trip (within quantization tolerance)
+# ============================================
+
+# Encode then decode, check max absolute error < 0.01
+query I
+SELECT max(abs(a - b)) < 0.01
+FROM (
+    SELECT unnest(pdxearch_decode_blob(pdxearch_encode_blob([1.0, -0.5, 0.001, 0.0, -0.001]::FLOAT[]))) AS a,
+           unnest([1.0, -0.5, 0.001, 0.0, -0.001]::FLOAT[]) AS b
+);
+----
+true
+
+# ============================================
+# 2. Base64 round-trip (exact)
+# ============================================
+
+query I
+SELECT pdxearch_base64_to_blob(pdxearch_blob_to_base64(pdxearch_encode_blob([1.0, -0.5, 0.25]::FLOAT[])))
+    = pdxearch_encode_blob([1.0, -0.5, 0.25]::FLOAT[]);
+----
+true
+
+# ============================================
+# 3. Distance function correctness with blob
+# ============================================
+
+statement ok
+CREATE TABLE t1 (id INTEGER, emb FLOAT[3]);
+
+statement ok
+INSERT INTO t1 VALUES (1, [1.0, 0.0, 0.0]), (2, [0.0, 1.0, 0.0]), (3, [0.0, 0.0, 1.0]);
+
+# array_distance with blob on left
+query I
+SELECT round(array_distance(pdxearch_encode_blob([1.0, 0.0, 0.0]::FLOAT[]), emb)::DECIMAL(18,4), 2) FROM t1 ORDER BY id;
+----
+0.00
+1.41
+1.41
+
+# array_distance with blob on right
+query I
+SELECT round(array_distance(emb, pdxearch_encode_blob([1.0, 0.0, 0.0]::FLOAT[]))::DECIMAL(18,4), 2) FROM t1 ORDER BY id;
+----
+0.00
+1.41
+1.41
+
+# array_cosine_distance with blob (identical=0, orthogonal=1)
+query I
+SELECT round(array_cosine_distance(pdxearch_encode_blob([1.0, 0.0, 0.0]::FLOAT[]), emb)::DECIMAL(18,4), 2) FROM t1 ORDER BY id;
+----
+0.00
+1.00
+1.00
+
+# <-> operator with blob
+query I
+SELECT round((pdxearch_encode_blob([1.0, 0.0, 0.0]::FLOAT[]) <-> emb)::DECIMAL(18,4), 2) FROM t1 ORDER BY id;
+----
+0.00
+1.41
+1.41
+
+# <=> operator with blob
+query I
+SELECT round((pdxearch_encode_blob([1.0, 0.0, 0.0]::FLOAT[]) <=> emb)::DECIMAL(18,4), 4) FROM t1 WHERE id = 1;
+----
+0.0000
+
+statement ok
+DROP TABLE t1;
+
+# ============================================
+# 4. Optimizer recognition: EXPLAIN shows PDXEARCH_INDEX_SCAN with blob query
+# ============================================
+
+test-env DIMS 128
+
+test-env NUM_ROWS 20000
+
+test-env QUERY_EMB [0,16,35,5,32,31,14,10,11,78,55,10,45,83,11,6,14,57,102,75,20,8,3,5,67,17,19,26,5,0,1,22,60,26,7,1,18,22,84,53,85,119,119,4,24,18,7,7,1,81,106,102,72,30,6,0,9,1,9,119,72,1,4,33,119,29,6,1,0,1,14,52,119,30,3,0,0,55,92,111,2,5,4,9,22,89,96,14,1,0,1,82,59,16,20,5,25,14,11,4,0,0,1,26,47,23,4,0,0,4,38,83,30,14,9,4,9,17,23,41,0,0,2,8,19,25,23,1]
+
+statement ok
+CREATE TABLE t2 (id INTEGER, emb FLOAT[${DIMS}]);
+
+statement ok
+INSERT INTO t2 FROM read_parquet('test/assets/sift-128-euclidean-245760.parquet') LIMIT ${NUM_ROWS};
+
+statement ok
+SET late_materialization_max_rows = 0;
+
+foreach metric_name,distance_func l2sq,array_distance cosine,array_cosine_distance
+
+statement ok
+DROP INDEX IF EXISTS t2_idx;
+
+statement ok
+CREATE INDEX t2_idx ON t2 USING PDXEARCH (emb) WITH (metric = '${metric_name}');
+
+# Index scan is used with blob query
+query II
+EXPLAIN SELECT * FROM t2 ORDER BY ${distance_func}(emb, pdxearch_encode_blob(${QUERY_EMB}::FLOAT[${DIMS}]::FLOAT[])) LIMIT 10;
+----
+physical_plan	<REGEX>:.*PDXEARCH_INDEX_SCAN.*
+
+endloop
+
+# ============================================
+# 5. Operator aliases work with blob
+# ============================================
+
+statement ok
+DROP INDEX IF EXISTS t2_idx;
+
+statement ok
+CREATE INDEX t2_idx ON t2 USING PDXEARCH (emb) WITH (metric = 'l2sq');
+
+query II
+EXPLAIN SELECT * FROM t2 ORDER BY emb <-> pdxearch_encode_blob(${QUERY_EMB}::FLOAT[${DIMS}]::FLOAT[]) LIMIT 10;
+----
+physical_plan	<REGEX>:.*PDXEARCH_INDEX_SCAN.*
+
+statement ok
+DROP INDEX IF EXISTS t2_idx;
+
+statement ok
+CREATE INDEX t2_idx ON t2 USING PDXEARCH (emb) WITH (metric = 'cosine');
+
+query II
+EXPLAIN SELECT * FROM t2 ORDER BY emb <=> pdxearch_encode_blob(${QUERY_EMB}::FLOAT[${DIMS}]::FLOAT[]) LIMIT 10;
+----
+physical_plan	<REGEX>:.*PDXEARCH_INDEX_SCAN.*
+
+statement ok
+DROP TABLE t2;


### PR DESCRIPTION
- Add lossy int16 quantization codec for encoding float vectors as compact BLOBs
- Register BLOB-accepting overloads of array_distance, array_cosine_distance, <->, <=>
- Teach the optimizer to recognize BLOB query constants and use PDXEARCH_INDEX_SCAN
- Add utility functions for encode/decode and base64 serialization

Rationale:
DuckDB's parser and constant-folding for ARRAY<FLOAT>[N] literals is slow — for a 768-dimensional embedding, the query string contains 768 comma-separated floats that must each be parsed, typed, and folded. A pre-encoded BLOB constant sidesteps this entirely: the query vector is a single opaque string literal that passes through the parser instantly.

Encoding Scheme:

Each float is quantized to a signed int16 using a multi-scale encoding:
- Lower 2 bits = scale selector X (0–3)
- Upper 14 bits = quantized value Q (signed, -8192 to 8191)
- Decode: float = (int16 >> 2) * scale[X] where scale = {1e-5, 1e-4, 1e-3, 1e-2}
- Encode: pick smallest X where round(float * inv_scale[X]) fits in [-8192, 8191]

Blob size = N × 2 bytes (no header). This is lossy but sufficient for ANN search where the index itself uses quantized representations.

Key Components:

pdxearch_blob_codec.hpp — Header-only codec:
- EncodeFloatToInt16(float) / DecodeInt16ToFloat(int16_t) — per-element encode/decode
- EncodeFloatArrayToBlob() / DecodeBlobToFloatArray() — bulk array encode/decode
- BlobDimensionCount(blob_byte_size) — returns blob_byte_size / 2

pdxearch_blob_functions.cpp — SQL-facing functions:
- pdxearch_encode_blob(LIST<FLOAT>) → BLOB — encode a float list to quantized blob
- pdxearch_decode_blob(BLOB) → LIST<FLOAT> — decode back
- pdxearch_blob_to_base64(BLOB) → VARCHAR / pdxearch_base64_to_blob(VARCHAR) → BLOB — serialization helpers
- BLOB overloads for all 4 distance functions (both argument orderings)

Optimizer changes:
- MakeFunctionMatcher() — matchers accept {ARRAY<FLOAT>[N], BLOB} via SetTypesMatcher
- TryOptimize() — branches on constant type: BLOB path decodes via DecodeBlobToFloatArray, ARRAY path unchanged

Test Plan:
- Encode/decode round-trip within quantization tolerance
- Base64 round-trip (exact)
- Distance function correctness (both argument orderings, all 4 function names)
- EXPLAIN confirms PDXEARCH_INDEX_SCAN with blob queries
- All 16 existing test cases continue to pass (1083 assertions)

Example: C++ Benchmark Generator
================================

For a C++ benchmark that has a float[N] query vector and needs to emit a DuckDB SQL query string using the blob encoding:

// --- Blob codec (mirrors pdxearch_blob_codec.hpp) ---

constexpr float BLOB_SCALE[4] = {0.00001f, 0.0001f, 0.001f, 0.01f}; constexpr float BLOB_INV_SCALE[4] = {100000.0f, 10000.0f, 1000.0f, 100.0f};

int16_t EncodeFloatToInt16(float value) {
    for (int x = 0; x < 4; x++) {
        auto q = static_cast<int32_t>(std::round(value * BLOB_INV_SCALE[x]));
        if (q >= -8192 && q <= 8191) {
            return static_cast<int16_t>((q << 2) | x);
        }
    }
    auto q = std::clamp(static_cast<int32_t>(std::round(value * BLOB_INV_SCALE[3])), -8192, 8191);
    return static_cast<int16_t>((q << 2) | 3);
}

// --- Base64 encoder ---

static const char B64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";

std::string ToBase64(const uint8_t *data, size_t len) {
    std::string out;
    out.reserve(4 * ((len + 2) / 3));
    for (size_t i = 0; i < len; i += 3) {
        uint32_t n = static_cast<uint32_t>(data[i]) << 16;
        if (i + 1 < len) n |= static_cast<uint32_t>(data[i + 1]) << 8;
        if (i + 2 < len) n |= static_cast<uint32_t>(data[i + 2]);
        out += B64[(n >> 18) & 0x3F];
        out += B64[(n >> 12) & 0x3F];
        out += (i + 1 < len) ? B64[(n >> 6) & 0x3F] : '=';
        out += (i + 2 < len) ? B64[n & 0x3F] : '=';
    }
    return out;
}

// --- Query generation ---

std::string MakeBlobQuery(const float *query_vec, size_t dims,
                          const std::string &table, const std::string &col,
                          const std::string &metric, size_t limit) {
    // Encode to int16 blob
    std::vector<int16_t> encoded(dims);
    for (size_t i = 0; i < dims; i++) {
        encoded[i] = EncodeFloatToInt16(query_vec[i]);
    }

    // Convert to base64
    auto b64 = ToBase64(reinterpret_cast<const uint8_t *>(encoded.data()),
                        dims * sizeof(int16_t));

    // Pick distance function
    std::string dist_func = (metric == "cosine") ? "array_cosine_distance" : "array_distance";

    // Emit SQL
    std::ostringstream sql;
    sql << "SELECT * FROM " << table
        << " ORDER BY " << dist_func << "(" << col
        << ", pdxearch_base64_to_blob('" << b64 << "'))"
        << " LIMIT " << limit << ";";
    return sql.str();
}

Usage:

float query[128] = { /* ... */ };
auto sql = MakeBlobQuery(query, 128, "embeddings", "vec", "l2sq", 10); // Produces:
// SELECT * FROM embeddings ORDER BY array_distance(vec, pdxearch_base64_to_blob('...base64...')) LIMIT 10;