### PR TITLE
Add basic concurrency locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ official VSS extension ([VSS docs](https://duckdb.org/docs/stable/core_extension
     INSERT INTO t1 (id, embedding) SELECT i as id, repeat([i], 512) FROM range(20000) t(i);
     ```
 
-4. Create the PDXearch index to speed up vector similarity search queries. Optionally, configure the index (e.g., the `metric` option). For all options see the [configuration](### Configuration) section.
+4. Create the PDXearch index to speed up vector similarity search queries. Optionally, configure the index (e.g., the `metric` option). For all options see the [configuration](#configuration) section.
 
     ```sql
     CREATE INDEX t1_idx ON t1 USING PDXEARCH (embedding) WITH (metric = 'l2sq');

--- a/src/include/index/pdxearch_index.hpp
+++ b/src/include/index/pdxearch_index.hpp
@@ -4,6 +4,7 @@
 #include "duckdb/execution/index/index_pointer.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/optimizer/matcher/expression_matcher.hpp"
+#include "duckdb/storage/storage_lock.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
 
 #include "pdxearch/common.hpp"
@@ -34,6 +35,15 @@ private:
 	unique_ptr<ExpressionMatcher> function_matcher;
 	IndexPointer root_block_ptr;
 
+	// A readers-writers (shared-exclusive; exclusive prioritized) lock to
+	// enforce a "one reader (exclusive) - one maintenance operation at a
+	// time (exclusive)" access pattern. DuckDB's IndexLock is also acquired
+	// implicitly in BoundIndex, but this is insufficient to guard 1+ index
+	// scans from the maintenance operations. Hence, we add this rwlock.
+	//
+	// See the pull request this was introduced in for more context.
+	StorageLock rwlock;
+
 public:
 	PDXearchIndex(const string &name, IndexConstraintType index_constraint_type, const vector<column_t> &column_ids,
 	              TableIOManager &table_io_manager, const vector<unique_ptr<Expression>> &unbound_expressions,
@@ -45,6 +55,8 @@ public:
 	/******************************************************************
 	 * Index creation and search methods specific to the parallel implementation
 	 ******************************************************************/
+
+	unique_ptr<StorageLockKey> TakeSearchLock();
 
 	void SetUpIndexForRowGroup(const row_t *row_ids, const float *embeddings, idx_t num_embeddings, idx_t row_group_id);
 

--- a/src/include/index/pdxearch_wrapper.hpp
+++ b/src/include/index/pdxearch_wrapper.hpp
@@ -27,7 +27,7 @@ public:
 private:
 	const uint32_t num_dimensions;
 	// Whether the embeddings (both the query embeddings and those stored in the
-	// index) are normalized. The PDXearch kernel only implements Euclidian
+	// index) are normalized. The PDXearch kernel only implements Euclidean
 	// distance (L2SQ). To compute the cosine and inner product distances we
 	// normalize and then use L2SQ.
 	const bool is_normalized;

--- a/src/index/pdxearch_index.cpp
+++ b/src/index/pdxearch_index.cpp
@@ -87,6 +87,10 @@ PDXearchIndex::PDXearchIndex(const string &name, IndexConstraintType index_const
  * Index creation and search methods specific to the parallel implementation
  ******************************************************************/
 
+unique_ptr<StorageLockKey> PDXearchIndex::TakeSearchLock() {
+	return rwlock.GetExclusiveLock();
+}
+
 void PDXearchIndex::SetUpIndexForRowGroup(const row_t *const row_ids, const float *const vectors,
                                           const idx_t num_vectors, const idx_t row_group_id) {
 	if (pdxearch_wrapper->GetQuantization() == PDX::U8) {
@@ -211,18 +215,31 @@ PDXearchIndex::GlobalFilteredSearch(const float *const query_embedding, const id
  ******************************************************************/
 
 ErrorData PDXearchIndex::Append(IndexLock &lock, DataChunk &entries, Vector &row_ids) {
-	throw NotImplementedException("PDXearchIndex::Append() not implemented");
+	// Execute all column expressions before inserting the data chunk.
+	DataChunk expr_chunk;
+	expr_chunk.Initialize(Allocator::DefaultAllocator(), logical_types);
+	ExecuteExpressions(entries, expr_chunk);
+	// Now insert the data chunk.
+	return Insert(lock, expr_chunk, row_ids);
 }
 
 ErrorData PDXearchIndex::Insert(IndexLock &lock, DataChunk &data, Vector &row_ids) {
+	auto _lock = rwlock.GetExclusiveLock();
+
 	throw NotImplementedException("PDXearchIndex::Insert() not implemented");
 }
 
 void PDXearchIndex::Delete(IndexLock &lock, DataChunk &entries, Vector &row_ids) {
+	auto _lock = rwlock.GetExclusiveLock();
+
 	throw NotImplementedException("PDXearchIndex::Delete() not implemented");
 }
 
+// DROP INDEX.
 void PDXearchIndex::CommitDrop(IndexLock &lock) {
+	auto _lock = rwlock.GetExclusiveLock();
+
+	// TODO: Implement when we implement persistence.
 }
 
 bool PDXearchIndex::MergeIndexes(IndexLock &state, BoundIndex &other_index) {
@@ -245,6 +262,8 @@ void PDXearchIndex::VerifyAllocations(IndexLock &state) {
 }
 
 idx_t PDXearchIndex::GetInMemorySize(IndexLock &state) {
+	auto _lock = rwlock.GetSharedLock();
+
 	return pdxearch_wrapper->GetInMemorySizeInBytes();
 }
 
@@ -273,6 +292,8 @@ IndexStorageInfo PDXearchIndex::SerializeToDisk(QueryContext context,
 	// For serialization_options see:
 	// https://github.com/duckdb/duckdb/blob/32afee3e788394973ce4df4fcae7610832d5550a/src/storage/write_ahead_log.cpp#L374
 
+	PersistToDisk();
+
 	IndexStorageInfo info(name);
 	case_insensitive_map_t<Value> options;
 	options.emplace("testDisk", Value::INTEGER(12));
@@ -285,6 +306,8 @@ IndexStorageInfo PDXearchIndex::SerializeToDisk(QueryContext context,
 }
 
 IndexStorageInfo PDXearchIndex::SerializeToWAL(const case_insensitive_map_t<Value> &serialization_options) {
+	PersistToDisk();
+
 	IndexStorageInfo info(name);
 	case_insensitive_map_t<Value> options;
 	options.emplace("testWAL", Value::INTEGER(12));
@@ -298,6 +321,7 @@ IndexStorageInfo PDXearchIndex::SerializeToWAL(const case_insensitive_map_t<Valu
 
 // TODO: Implement persistence.
 void PDXearchIndex::PersistToDisk() {
+	auto _lock = rwlock.GetExclusiveLock();
 }
 
 /******************************************************************

--- a/src/index/search/pdxearch_index_filtered_scan_physical.cpp
+++ b/src/index/search/pdxearch_index_filtered_scan_physical.cpp
@@ -3,6 +3,7 @@
 #include "index/pdxearch_index.hpp"
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/storage/data_table.hpp"
+#include "duckdb/storage/storage_lock.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/transaction/local_storage.hpp"
 #include "duckdb/parallel/base_pipeline_event.hpp"
@@ -27,7 +28,8 @@ class PhysicalFilteredScanGlobalSinkState : public GlobalSinkState {
 public:
 	PhysicalFilteredScanGlobalSinkState(ClientContext &context, const PhysicalPDXearchIndexFilteredScan &op,
 	                                    const PDXearchIndexPhysicalScanBindData &bind_data)
-	    : context(context), op(op), limit(bind_data.limit), index(bind_data.index.Cast<PDXearchIndex>()),
+	    : search_lock(bind_data.index.Cast<PDXearchIndex>().TakeSearchLock()), context(context), op(op),
+	      limit(bind_data.limit), index(bind_data.index.Cast<PDXearchIndex>()),
 	      preprocessed_query_embedding(make_uniq_array<float>(index.GetNumDimensions())), pdxearch_row_ids(nullptr) {
 		// Preprocess the query embedding.
 		EmbeddingPreprocessor embedding_preprocessor(index.GetNumDimensions(), index.GetRotationMatrix());
@@ -51,6 +53,12 @@ public:
 
 		row_group_ids_of_row_groups_with_passing_tuples.reserve(index.GetNumRowGroups());
 	}
+
+	// Held for the duration of execution to serialize searches against index
+	// maintenance (and against other searches). Declared first so it is
+	// constructed first and destroyed last, ensuring the lock is held while all
+	// other members (which reference index state) are torn down.
+	unique_ptr<StorageLockKey> search_lock;
 
 	const ClientContext &context;
 	const PhysicalPDXearchIndexFilteredScan &op;

--- a/src/index/search/pdxearch_index_global_filtered_scan_physical.cpp
+++ b/src/index/search/pdxearch_index_global_filtered_scan_physical.cpp
@@ -2,6 +2,7 @@
 #include "index/pdxearch_index.hpp"
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/storage/data_table.hpp"
+#include "duckdb/storage/storage_lock.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/transaction/local_storage.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
@@ -10,8 +11,15 @@ namespace duckdb {
 
 class PhysicalGlobalFilteredScanGlobalSinkState : public GlobalSinkState {
 public:
-	PhysicalGlobalFilteredScanGlobalSinkState() : collected_vectors(), pdxearch_row_ids(nullptr) {
+	explicit PhysicalGlobalFilteredScanGlobalSinkState(PDXearchIndex &index)
+	    : search_lock(index.TakeSearchLock()), collected_vectors(), pdxearch_row_ids(nullptr) {
 	}
+
+	// Held for the duration of execution to serialize searches against index
+	// maintenance (and against other searches). Declared first so it is
+	// constructed first and destroyed last, ensuring the lock is held while all
+	// other members (which reference index state) are torn down.
+	unique_ptr<StorageLockKey> search_lock;
 
 	std::vector<std::pair<Vector, idx_t>> collected_vectors;
 	std::unique_ptr<std::vector<row_t>> pdxearch_row_ids;
@@ -56,7 +64,7 @@ PhysicalGlobalPDXearchIndexFilteredScan::PhysicalGlobalPDXearchIndexFilteredScan
 // ------------------------------
 
 unique_ptr<GlobalSinkState> PhysicalGlobalPDXearchIndexFilteredScan::GetGlobalSinkState(ClientContext &context) const {
-	return make_uniq<PhysicalGlobalFilteredScanGlobalSinkState>();
+	return make_uniq<PhysicalGlobalFilteredScanGlobalSinkState>(bind_data->index.Cast<PDXearchIndex>());
 }
 
 unique_ptr<LocalSinkState> PhysicalGlobalPDXearchIndexFilteredScan::GetLocalSinkState(ExecutionContext &context) const {

--- a/src/index/search/pdxearch_index_global_scan.cpp
+++ b/src/index/search/pdxearch_index_global_scan.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/storage/storage_lock.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/transaction/local_storage.hpp"
@@ -18,6 +19,12 @@ BindInfo PDXearchIndexScanBindInfo(const optional_ptr<FunctionData> bind_data_p)
 }
 
 struct PDXearchIndexScanGlobalState : public GlobalTableFunctionState {
+	// Held for the duration of the scan to serialize searches against index
+	// maintenance (and against other searches). Declared first so it is
+	// constructed first and destroyed last, ensuring the lock is held while all
+	// other members (which reference index state) are torn down.
+	unique_ptr<StorageLockKey> search_lock;
+
 	ColumnFetchState fetch_state;
 	TableScanState local_storage_state;
 	vector<StorageIndex> column_ids;
@@ -31,6 +38,8 @@ static unique_ptr<GlobalTableFunctionState> PDXearchIndexScanInitGlobal(ClientCo
 	auto &bind_data = input.bind_data->Cast<PDXearchIndexScanBindData>();
 
 	auto result = make_uniq<PDXearchIndexScanGlobalState>();
+
+	result->search_lock = bind_data.index.Cast<PDXearchIndex>().TakeSearchLock();
 
 	// Set up the scan state for the local storage
 	auto &local_storage = LocalStorage::Get(context, bind_data.table.catalog);

--- a/src/index/search/pdxearch_index_scan_physical.cpp
+++ b/src/index/search/pdxearch_index_scan_physical.cpp
@@ -4,6 +4,7 @@
 #include "index/pdxearch_index_utils.hpp"
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/storage/data_table.hpp"
+#include "duckdb/storage/storage_lock.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/transaction/local_storage.hpp"
 #include "duckdb/parallel/executor_task.hpp"
@@ -23,7 +24,8 @@ public:
 	PDXearchScanGlobalSourceState(ClientContext &context, const PhysicalPDXearchIndexScan &op,
 	                              const PDXearchIndexScanBindData &bind_data,
 	                              const vector<ColumnIndex> &operator_column_ids)
-	    : context(context), op(op), limit(bind_data.limit), index(bind_data.index.Cast<PDXearchIndex>()),
+	    : search_lock(bind_data.index.Cast<PDXearchIndex>().TakeSearchLock()), context(context), op(op),
+	      limit(bind_data.limit), index(bind_data.index.Cast<PDXearchIndex>()),
 	      preprocessed_query_embedding(make_uniq_array<float>(index.GetNumDimensions())), search_started(false),
 	      search_completed(false), pdxearch_row_ids(nullptr), pdxearch_row_ids_idx(0) {
 		// Preprocess the query embedding.
@@ -65,6 +67,12 @@ public:
 		auto &local_storage = LocalStorage::Get(context, bind_data.table.catalog);
 		local_storage.InitializeScan(bind_data.table.GetStorage(), local_storage_state.local_state, nullptr);
 	}
+
+	// Held for the duration of execution to serialize searches against index
+	// maintenance (and against other searches). Declared first so it is
+	// constructed first and destroyed last, ensuring the lock is held while all
+	// other members (which reference index state) are torn down.
+	unique_ptr<StorageLockKey> search_lock;
 
 	ClientContext &context;
 	const PhysicalPDXearchIndexScan &op;


### PR DESCRIPTION
## Changes

- This PR adds locking for a minimalistic "serial reads, serial maintenance" approach.

## Next up

For the alpha I'd like to support "concurrent reads, serial maintenance", but we need to make other changes before adjusting the locking to allow that. The concurrency tests will follow with those changes.

Next up for concurrency: merging the refactored PDX library back in to the extension, ensuring the search state is ephemeral (so we can execute multiple index scans in parallel), then 1) adjust the exclusive read lock to a shared lock, and 2) add concurrency tests.

## Background

### Locking approach

DuckDB’s BoundIndex class has multiple methods that need to be implemented: Append, TryDelete, .... DuckDB implicitly holds an exclusive IndexLock mutex when these are called. Other methods that you add to your BoundIndex subclass yourself (Search, FilteredSearch, GetIndexStats) do not call this lock. To enforce correct access, you can:
1) like the RTree (spatial extension) not take the IndexLock at all on scans. This to me seems like it could be problematic with concurrent writes. But under a “bulk load then scan” workload this seems fine. I guess it is a lock-free data structure or another part of the system avoids any issues [[1]](https://github.com/duckdb/duckdb-spatial/issues/706).
2) like the ART index, explicitly/manually take the IndexLock on your other methods (Search, GetIndexStats).
This is a simple approach (because you use the IndexLock), but this disallows concurrent reads. For the ART index an exclusive lock during a scan might be fine, as its operations are cheap (so the critical section is “short”).
3) like the DuckDB VSS’ HNSW index, you do not touch the IndexLock (note that, as just mentioned, it will still be used implicitly) and instead add your own reader-writer lock (e.g., StorageLock) inside your index class.
This is a more "complex" approach since you now have two locks. This reader-writer lock allows you to differentiate between concurrent reads, and exclusive appends/deletes, etc. PDXearch index reads are expensive, so serializing those single-threaded reads with the standard IndexLock seems suboptimal compared to concurrently searching under a shared (read) lock.

We use approach 3.

### DuckDB concurrency model

As far as I understand, DuckDB has the following concurrency model:

- [Two modes](https://duckdb.org/docs/current/connect/concurrency)
  - Read-write mode: one process can both read and write to the database.
    - Why one process? → shared state in RAM.
    - [Multiple](https://duckdb.org/docs/current/guides/python/multiple_threads) threads.
      - _So 2 threads could be writing and 2 threads could be reading at the same time._
    - You set up an initial connection (duckdb.connect(db_name)), then each thread creates a thread-local connection using local_con = duckdb_con.cursor().
  - Read-only mode: multiple processes can read from the database, but no processes can write (access_mode = 'READ_ONLY').
    - _So 2 processes with 2 threads each (4 threads in total) could be reading at the same time._
- Enforcing the one vs. multiple processes access on a database file is through file locks.